### PR TITLE
4.x dev

### DIFF
--- a/src/Core/util/infoFetcher.ts
+++ b/src/Core/util/infoFetcher.ts
@@ -41,6 +41,5 @@ export const infoFetcher = (url: string) => {
                 }
             });
         }
-        eventSender('play_title_bgm_target', 1, 0);
     });
 };


### PR DESCRIPTION
在index.html里已经设置过了播放bgm的自定义事件，点击触发enter函数生效，所以在initializeScript/infoFetcher中再次发送bgm事件是冗余的，而且会让chrome控制台报错：play() failed because the user didn‘t interact with the document first

根据chrome新特性，开发者不能利用手中权限去给用户造成噪音干扰，首次加载页面需要用户和audio/video进行交互