### PR TITLE
Disable appreciation mode button when there are no appreciation items

### DIFF
--- a/packages/webgal/src/UI/Title/Title.tsx
+++ b/packages/webgal/src/UI/Title/Title.tsx
@@ -30,6 +30,10 @@ const Title: FC = () => {
 
   const applyStyle = useApplyStyle('UI/Title/title.scss');
   useConfigData(); // 监听基础ConfigData变化
+
+  const appreciationItems = useSelector((state: RootState) => state.userData.appreciationData);
+  const hasAppreciationItems = appreciationItems.bgm.length > 0 || appreciationItems.cg.length > 0;
+
   return (
     <>
       {GUIState.showTitle && <div className={applyStyle('Title_backup_background', styles.Title_backup_background)} />}
@@ -98,12 +102,15 @@ const Title: FC = () => {
               <div className={applyStyle('Title_button_text', styles.Title_button_text)}>{t('load.title')}</div>
             </div>
             <div
-              className={applyStyle('Title_button', styles.Title_button)}
+              className={`${applyStyle('Title_button', styles.Title_button)} ${!hasAppreciationItems ? styles.Title_button_disabled : ''}`}
               onClick={() => {
-                playSeClick();
-                dispatch(setVisibility({ component: 'showExtra', visibility: true }));
+                if (hasAppreciationItems) {
+                  playSeClick();
+                  dispatch(setVisibility({ component: 'showExtra', visibility: true }));
+                }
               }}
               onMouseEnter={playSeEnter}
+              disabled={!hasAppreciationItems}
             >
               <div className={applyStyle('Title_button_text', styles.Title_button_text)}>{t('extra.title')}</div>
             </div>

--- a/packages/webgal/src/UI/Title/Title.tsx
+++ b/packages/webgal/src/UI/Title/Title.tsx
@@ -102,7 +102,9 @@ const Title: FC = () => {
               <div className={applyStyle('Title_button_text', styles.Title_button_text)}>{t('load.title')}</div>
             </div>
             <div
-              className={`${applyStyle('Title_button', styles.Title_button)} ${!hasAppreciationItems ? styles.Title_button_disabled : ''}`}
+              className={`${applyStyle('Title_button', styles.Title_button)} ${
+                !hasAppreciationItems ? styles.Title_button_disabled : ''
+              }`}
               onClick={() => {
                 if (hasAppreciationItems) {
                   playSeClick();
@@ -110,7 +112,6 @@ const Title: FC = () => {
                 }
               }}
               onMouseEnter={playSeEnter}
-              disabled={!hasAppreciationItems}
             >
               <div className={applyStyle('Title_button_text', styles.Title_button_text)}>{t('extra.title')}</div>
             </div>

--- a/packages/webgal/src/UI/Title/title.module.scss
+++ b/packages/webgal/src/UI/Title/title.module.scss
@@ -54,6 +54,6 @@
 }
 
 .Title_button_disabled {
-  cursor: not-allowed;
+  cursor: not-allowed !important;
   opacity: 0.5;
 }

--- a/packages/webgal/src/UI/Title/title.module.scss
+++ b/packages/webgal/src/UI/Title/title.module.scss
@@ -52,3 +52,8 @@
   z-index: 13;
   background: linear-gradient(135deg, #fdfbfb 0%, #dcddde 100%);
 }
+
+.Title_button_disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}


### PR DESCRIPTION
Fixes #641

Disable the appreciation mode button when there are no appreciation items.

* Add a check for appreciation items in `packages/webgal/src/UI/Title/Title.tsx` using `useSelector` to determine if there are any appreciation items.
* Modify the appreciation mode button to include a `disabled` attribute and a conditional class for when there are no appreciation items.
* Update the styles in `packages/webgal/src/UI/Title/title.module.scss` to include a new class for the disabled state of the appreciation mode button.

