### PR TITLE
fix: live2d figure initial position when bounds are modified

### DIFF
--- a/packages/webgal/src/Core/controller/stage/pixi/PixiController.ts
+++ b/packages/webgal/src/Core/controller/stage/pixi/PixiController.ts
@@ -678,6 +678,8 @@ export default class PixiStage {
               model.scale.x = targetScale;
               model.scale.y = targetScale;
               model.anchor.set(0.5);
+              model.pivot.x += (overrideBounds[0] + overrideBounds[2]) * 0.5;
+              model.pivot.y += (overrideBounds[1] + overrideBounds[3]) * 0.5;
               model.position.x = 0;
               model.position.y = stageHeight / 2;
 


### PR DESCRIPTION
# 介绍
修复 Live2d 立绘修改 bounds 后的初始定位问题, 现在无论 bounds 怎么改, 都会像不改 bounds 的立绘一样尽量贴边

| 对比 | 预览图 |
| :-----: | :-----: |
| Before | <img src=https://github.com/user-attachments/assets/b6800edc-5e7b-4f57-8aa5-bde985951266> |
| After | <img src=https://github.com/user-attachments/assets/17a198a1-6f24-4d41-9c94-e71a37e68328> |