### PR TITLE
feat: 支持 Spine 立绘动画切换功能

### DIFF
--- a/packages/webgal/src/Core/controller/stage/pixi/PixiController.ts
+++ b/packages/webgal/src/Core/controller/stage/pixi/PixiController.ts
@@ -40,6 +40,7 @@ export interface IStageObject {
   sourceUrl: string;
   sourceExt: string;
   sourceType: 'img' | 'live2d' | 'spine' | 'gif' | 'video';
+  spineAnimation?: string;
 }
 
 export interface ILive2DRecord {
@@ -782,7 +783,7 @@ export default class PixiStage {
   public changeSpineAnimationByKey(key: string, animation: string) {
     const target = this.figureObjects.find((e) => e.key === key);
     if (target?.sourceType !== 'spine') return;
-    
+
     const container = target.pixiContainer;
     // Spine figure 结构: Container -> Sprite -> Spine
     const sprite = container.children[0] as PIXI.Container;
@@ -792,9 +793,12 @@ export default class PixiStage {
       if (spineObject.state && spineObject.spineData) {
         // @ts-ignore
         const animationExists = spineObject.spineData.animations.find((anim: any) => anim.name === animation);
-        if (animationExists) {
+        let targetCurrentAnimation = target?.spineAnimation ?? '';
+        if (animationExists && targetCurrentAnimation !== animation) {
+          console.log(`setting animation ${animation}`);
+          target!.spineAnimation = animation;
           // @ts-ignore
-          spineObject.state.setAnimation(0, animation, true);
+          spineObject.state.setAnimation(0, animation, false);
         }
       }
     }

--- a/packages/webgal/src/Core/controller/stage/pixi/spine.ts
+++ b/packages/webgal/src/Core/controller/stage/pixi/spine.ts
@@ -56,6 +56,7 @@ export async function addSpineFigureImpl(
   key: string,
   url: string,
   presetPosition: 'left' | 'center' | 'right' = 'center',
+  motion: string = '',
 ) {
   const spineId = `spine-${url}`;
   const pixiSpine = await loadPixiSpine();
@@ -105,8 +106,14 @@ export async function addSpineFigureImpl(
       const spineCenterX = spineBounds.x + spineBounds.width / 2;
       const spineCenterY = spineBounds.y + spineBounds.height / 2;
       figureSpine.pivot.set(spineCenterX, spineCenterY);
-      // TODO: set animation 还没做
-      // figureSpine.state.setAnimation(0, figureSpine.spineData.animations[0].name, true)
+      
+      // 设置动画
+      if (motion && figureSpine.spineData.animations.find((anim: any) => anim.name === motion)) {
+        figureSpine.state.setAnimation(0, motion, true);
+      } else if (figureSpine.spineData.animations.length > 0) {
+        // 如果没有指定 motion 或 motion 不存在，播放第一个动画
+        figureSpine.state.setAnimation(0, figureSpine.spineData.animations[0].name, true);
+      }
 
       /**
        * 重设大小

--- a/packages/webgal/src/Core/controller/stage/pixi/spine.ts
+++ b/packages/webgal/src/Core/controller/stage/pixi/spine.ts
@@ -59,7 +59,6 @@ export async function addSpineFigureImpl(
   presetPosition: 'left' | 'center' | 'right' = 'center',
 ) {
   const spineId = `spine-${url}`;
-  const pixiSpine = await loadPixiSpine();
   // 准备用于存放这个立绘的 Container
   const thisFigureContainer = new WebGALPixiContainer();
 
@@ -88,73 +87,89 @@ export async function addSpineFigureImpl(
     sourceUrl: url,
     sourceType: 'spine', // 修改为 'spine'
     sourceExt: this.getExtName(url),
+    spineAnimation: '_initial',
   });
+  const pixiSpine = await loadPixiSpine();
 
   // 完成图片加载后执行的函数
   const setup = async () => {
-    if (!pixiSpine) {
-      // 无法加载 'pixi-spine'，跳过 Spine 相关逻辑
-      logger.warn(`Spine module not loaded. Skipping Spine figure: ${key}`);
-      return;
-    }
-
-    const { Spine } = pixiSpine;
-    const spineResource: any = spineLoader!.resources?.[spineId];
-    if (spineResource && this.getStageObjByUuid(figureUuid)) {
-      const figureSpine = new Spine(spineResource.spineData);
-      const spineBounds = figureSpine.getLocalBounds();
-      const spineCenterX = spineBounds.x + spineBounds.width / 2;
-      const spineCenterY = spineBounds.y + spineBounds.height / 2;
-      figureSpine.pivot.set(spineCenterX, spineCenterY);
-      
-      // 检查状态中是否有指定的动画
-      const motionFromState = webgalStore.getState().stage.live2dMotion.find((e) => e.target === key);
-      let animationToPlay = '';
-      
-      if (motionFromState && figureSpine.spineData.animations.find((anim: any) => anim.name === motionFromState.motion)) {
-        // 使用状态中指定的动画
-        animationToPlay = motionFromState.motion;
-      } else if (figureSpine.spineData.animations.length > 0) {
-        // 播放默认动画（第一个动画）
-        animationToPlay = figureSpine.spineData.animations[0].name;
-      }
-      
-      if (animationToPlay) {
-        figureSpine.state.setAnimation(0, animationToPlay, true);
+    setTimeout(() => {
+      console.log('Setting up Spine' + key + url);
+      if (!pixiSpine) {
+        // 无法加载 'pixi-spine'，跳过 Spine 相关逻辑
+        logger.warn(`Spine module not loaded. Skipping Spine figure: ${key}`);
+        return;
       }
 
-      /**
-       * 重设大小
-       */
-      const originalWidth = figureSpine.width;
-      const originalHeight = figureSpine.height;
-      const scaleX = this.stageWidth / originalWidth;
-      const scaleY = this.stageHeight / originalHeight;
-      const targetScale = Math.min(scaleX, scaleY);
-      const figureSprite = new PIXI.Sprite();
-      figureSprite.addChild(figureSpine);
-      figureSprite.scale.x = targetScale;
-      figureSprite.scale.y = targetScale;
-      figureSprite.anchor.set(0.5);
-      figureSprite.position.y = this.stageHeight / 2;
-      const targetWidth = originalWidth * targetScale;
-      const targetHeight = originalHeight * targetScale;
-      thisFigureContainer.setBaseY(this.stageHeight / 2);
-      if (targetHeight < this.stageHeight) {
-        thisFigureContainer.setBaseY(this.stageHeight / 2 + (this.stageHeight - targetHeight) / 2);
+      const { Spine } = pixiSpine;
+      const spineResource: any = spineLoader!.resources?.[spineId];
+      if (spineResource && this.getStageObjByUuid(figureUuid)) {
+        const figureSpine = new Spine(spineResource.spineData);
+        const spineBounds = figureSpine.getLocalBounds();
+        const spineCenterX = spineBounds.x + spineBounds.width / 2;
+        const spineCenterY = spineBounds.y + spineBounds.height / 2;
+        figureSpine.pivot.set(spineCenterX, spineCenterY);
+        figureSpine.interactive = false;
+
+        // 检查状态中是否有指定的动画
+        const motionFromState = webgalStore.getState().stage.live2dMotion.find((e) => e.target === key);
+        let animationToPlay = '';
+
+        if (
+          motionFromState &&
+          figureSpine.spineData.animations.find((anim: any) => anim.name === motionFromState.motion)
+        ) {
+          // 使用状态中指定的动画
+          animationToPlay = motionFromState.motion;
+        } else if (figureSpine.spineData.animations.length > 0) {
+          // 播放默认动画（第一个动画）
+          animationToPlay = figureSpine.spineData.animations[0].name;
+        }
+
+        if (animationToPlay) {
+          figureSpine.state.setAnimation(0, animationToPlay, false);
+          figureSpine.autoUpdate = true;
+          const stageObj = this.getStageObjByUuid(figureUuid);
+          if (stageObj) {
+            if (stageObj.spineAnimation) {
+              stageObj.spineAnimation = animationToPlay;
+            }
+          }
+        }
+
+        /**
+         * 重设大小
+         */
+        const originalWidth = figureSpine.width;
+        const originalHeight = figureSpine.height;
+        const scaleX = this.stageWidth / originalWidth;
+        const scaleY = this.stageHeight / originalHeight;
+        const targetScale = Math.min(scaleX, scaleY);
+        const figureSprite = new PIXI.Sprite();
+        figureSprite.addChild(figureSpine);
+        figureSprite.scale.x = targetScale;
+        figureSprite.scale.y = targetScale;
+        figureSprite.anchor.set(0.5);
+        figureSprite.position.y = this.stageHeight / 2;
+        const targetWidth = originalWidth * targetScale;
+        const targetHeight = originalHeight * targetScale;
+        thisFigureContainer.setBaseY(this.stageHeight / 2);
+        if (targetHeight < this.stageHeight) {
+          thisFigureContainer.setBaseY(this.stageHeight / 2 + (this.stageHeight - targetHeight) / 2);
+        }
+        if (presetPosition === 'center') {
+          thisFigureContainer.setBaseX(this.stageWidth / 2);
+        }
+        if (presetPosition === 'left') {
+          thisFigureContainer.setBaseX(targetWidth / 2);
+        }
+        if (presetPosition === 'right') {
+          thisFigureContainer.setBaseX(this.stageWidth - targetWidth / 2);
+        }
+        thisFigureContainer.pivot.set(0, this.stageHeight / 2);
+        thisFigureContainer.addChild(figureSprite);
       }
-      if (presetPosition === 'center') {
-        thisFigureContainer.setBaseX(this.stageWidth / 2);
-      }
-      if (presetPosition === 'left') {
-        thisFigureContainer.setBaseX(targetWidth / 2);
-      }
-      if (presetPosition === 'right') {
-        thisFigureContainer.setBaseX(this.stageWidth - targetWidth / 2);
-      }
-      thisFigureContainer.pivot.set(0, this.stageHeight / 2);
-      thisFigureContainer.addChild(figureSprite);
-    }
+    }, 0);
   };
 
   /**

--- a/packages/webgal/src/Stage/MainStage/useSetFigure.ts
+++ b/packages/webgal/src/Stage/MainStage/useSetFigure.ts
@@ -10,27 +10,6 @@ import { WebGAL } from '@/Core/WebGAL';
 
 export function useSetFigure(stageState: IStageState) {
   const { figNameLeft, figName, figNameRight, freeFigure, live2dMotion, live2dExpression } = stageState;
-  
-  // 定义内部的 addFigure 函数
-  function addFigure(type?: 'image' | 'live2D' | 'spine', ...args: any[]) {
-    const key = args[0];
-    const url = args[1];
-    const baseUrl = window.location.origin;
-    const urlObject = new URL(url, baseUrl);
-    const _type = urlObject.searchParams.get('type') as 'image' | 'live2D' | 'spine' | null;
-    if (url.endsWith('.json')) {
-      return addLive2dFigure(...args);
-    } else if (url.endsWith('.skel') || _type === 'spine') {
-      // 从 live2dMotion 中查找对应的 motion
-      const motionInfo = stageState.live2dMotion.find(m => m.target === key);
-      const motion = motionInfo?.motion || '';
-      // @ts-ignore
-      return WebGAL.gameplay.pixiStage?.addSpineFigure(key, url, args[2], motion);
-    } else {
-      // @ts-ignore
-      return WebGAL.gameplay.pixiStage?.addFigure(...args);
-    }
-  }
 
   /**
    * 同步 motion
@@ -226,6 +205,21 @@ function removeFig(figObj: IStageObject, enterTikerKey: string, effects: IEffect
   }, duration);
 }
 
+function addFigure(type?: 'image' | 'live2D' | 'spine', ...args: any[]) {
+  const url = args[1];
+  const baseUrl = window.location.origin;
+  const urlObject = new URL(url, baseUrl);
+  const _type = urlObject.searchParams.get('type') as 'image' | 'live2D' | 'spine' | null;
+  if (url.endsWith('.json')) {
+    return addLive2dFigure(...args);
+  } else if (url.endsWith('.skel') || _type === 'spine') {
+    // @ts-ignore
+    return WebGAL.gameplay.pixiStage?.addSpineFigure(...args);
+  } else {
+    // @ts-ignore
+    return WebGAL.gameplay.pixiStage?.addFigure(...args);
+  }
+}
 
 /**
  * 如果要使用 Live2D，取消这里的注释

--- a/packages/webgal/src/Stage/MainStage/useSetFigure.ts
+++ b/packages/webgal/src/Stage/MainStage/useSetFigure.ts
@@ -10,6 +10,27 @@ import { WebGAL } from '@/Core/WebGAL';
 
 export function useSetFigure(stageState: IStageState) {
   const { figNameLeft, figName, figNameRight, freeFigure, live2dMotion, live2dExpression } = stageState;
+  
+  // 定义内部的 addFigure 函数
+  function addFigure(type?: 'image' | 'live2D' | 'spine', ...args: any[]) {
+    const key = args[0];
+    const url = args[1];
+    const baseUrl = window.location.origin;
+    const urlObject = new URL(url, baseUrl);
+    const _type = urlObject.searchParams.get('type') as 'image' | 'live2D' | 'spine' | null;
+    if (url.endsWith('.json')) {
+      return addLive2dFigure(...args);
+    } else if (url.endsWith('.skel') || _type === 'spine') {
+      // 从 live2dMotion 中查找对应的 motion
+      const motionInfo = stageState.live2dMotion.find(m => m.target === key);
+      const motion = motionInfo?.motion || '';
+      // @ts-ignore
+      return WebGAL.gameplay.pixiStage?.addSpineFigure(key, url, args[2], motion);
+    } else {
+      // @ts-ignore
+      return WebGAL.gameplay.pixiStage?.addFigure(...args);
+    }
+  }
 
   /**
    * 同步 motion
@@ -205,21 +226,6 @@ function removeFig(figObj: IStageObject, enterTikerKey: string, effects: IEffect
   }, duration);
 }
 
-function addFigure(type?: 'image' | 'live2D' | 'spine', ...args: any[]) {
-  const url = args[1];
-  const baseUrl = window.location.origin;
-  const urlObject = new URL(url, baseUrl);
-  const _type = urlObject.searchParams.get('type') as 'image' | 'live2D' | 'spine' | null;
-  if (url.endsWith('.json')) {
-    return addLive2dFigure(...args);
-  } else if (url.endsWith('.skel') || _type === 'spine') {
-    // @ts-ignore
-    return WebGAL.gameplay.pixiStage?.addSpineFigure(...args);
-  } else {
-    // @ts-ignore
-    return WebGAL.gameplay.pixiStage?.addFigure(...args);
-  }
-}
 
 /**
  * 如果要使用 Live2D，取消这里的注释


### PR DESCRIPTION
## Summary
- 新增 Spine 立绘动画切换功能支持
- 优化 PixiJS 控制器中的 Spine 动画处理逻辑
- 改进立绘设置流程以支持动画切换

## Changes
- 修改 `PixiController.ts` 增强 Spine 动画控制
- 更新 `spine.ts` 添加动画切换相关功能
- 优化 `useSetFigure.ts` 支持新的动画切换机制

## Test plan
- [ ] 验证 Spine 立绘可以正常加载
- [ ] 测试动画切换功能是否正常工作
- [ ] 确认不影响现有立绘功能

🤖 Generated with [Claude Code](https://claude.ai/code)