### PR TITLE
fix: clear animation before exiting

### DIFF
--- a/packages/webgal/src/Core/controller/stage/pixi/PixiController.ts
+++ b/packages/webgal/src/Core/controller/stage/pixi/PixiController.ts
@@ -34,7 +34,7 @@ export interface IStageObject {
   uuid: string;
   // 一般与作用目标有关
   key: string;
-  pixiContainer: WebGALPixiContainer;
+  pixiContainer: WebGALPixiContainer | null;
   // 相关的源 url
   sourceUrl: string;
   sourceExt: string;
@@ -235,7 +235,7 @@ export default class PixiStage {
       const targetPixiContainer = this.getStageObjByKey(target);
       if (targetPixiContainer) {
         const container = targetPixiContainer.pixiContainer;
-        PixiStage.assignTransform(container, effect.transform);
+        if (container) PixiStage.assignTransform(container, effect.transform);
       }
       return;
     }
@@ -776,6 +776,7 @@ export default class PixiStage {
       const figureRecordTarget = this.live2dFigureRecorder.find((e) => e.target === key);
       if (target && figureRecordTarget?.motion !== motion) {
         const container = target.pixiContainer;
+        if (!container) return;
         const children = container.children;
         for (const model of children) {
           let category_name = motion;
@@ -799,6 +800,7 @@ export default class PixiStage {
     if (target?.sourceType !== 'spine') return;
 
     const container = target.pixiContainer;
+    if (!container) return;
     // Spine figure 结构: Container -> Sprite -> Spine
     const sprite = container.children[0] as PIXI.Container;
     if (sprite?.children?.[0]) {
@@ -825,6 +827,7 @@ export default class PixiStage {
     const figureRecordTarget = this.live2dFigureRecorder.find((e) => e.target === key);
     if (target && figureRecordTarget?.expression !== expression) {
       const container = target.pixiContainer;
+      if (!container) return;
       const children = container.children;
       for (const model of children) {
         // @ts-ignore
@@ -840,6 +843,7 @@ export default class PixiStage {
     const figureRecordTarget = this.live2dFigureRecorder.find((e) => e.target === key);
     if (target && !isEqual(figureRecordTarget?.blink, blinkParam)) {
       const container = target.pixiContainer;
+      if (!container) return;
       const children = container.children;
       let newBlinkParam: BlinkParam = { ...baseBlinkParam, ...blinkParam };
       // 继承现有 BlinkParam
@@ -860,6 +864,7 @@ export default class PixiStage {
     const figureRecordTarget = this.live2dFigureRecorder.find((e) => e.target === key);
     if (target && !isEqual(figureRecordTarget?.focus, focusParam)) {
       const container = target.pixiContainer;
+      if (!container) return;
       const children = container.children;
       let newFocusParam: FocusParam = { ...baseFocusParam, ...focusParam };
       // 继承现有 FocusParam
@@ -883,6 +888,7 @@ export default class PixiStage {
     const target = this.figureObjects.find((e) => e.key === key);
     if (target && target.sourceType === 'live2d') {
       const container = target.pixiContainer;
+      if (!container) return;
       const children = container.children;
       for (const model of children) {
         // @ts-ignore
@@ -925,20 +931,26 @@ export default class PixiStage {
     const indexBg = this.backgroundObjects.findIndex((e) => e.key === key);
     if (indexFig >= 0) {
       const bgSprite = this.figureObjects[indexFig];
-      for (const element of bgSprite.pixiContainer.children) {
-        element.destroy();
+      if (bgSprite.pixiContainer) {
+        for (const element of bgSprite.pixiContainer.children) {
+          element.destroy();
+        }
+        bgSprite.pixiContainer.destroy();
+        this.figureContainer.removeChild(bgSprite.pixiContainer);
       }
-      bgSprite.pixiContainer.destroy();
-      this.figureContainer.removeChild(bgSprite.pixiContainer);
+      bgSprite.pixiContainer = null;
       this.figureObjects.splice(indexFig, 1);
     }
     if (indexBg >= 0) {
       const bgSprite = this.backgroundObjects[indexBg];
-      for (const element of bgSprite.pixiContainer.children) {
-        element.destroy();
+      if (bgSprite.pixiContainer) {
+        for (const element of bgSprite.pixiContainer.children) {
+          element.destroy();
+        }
+        bgSprite.pixiContainer.destroy();
+        this.backgroundContainer.removeChild(bgSprite.pixiContainer);
       }
-      bgSprite.pixiContainer.destroy();
-      this.backgroundContainer.removeChild(bgSprite.pixiContainer);
+      bgSprite.pixiContainer = null;
       this.backgroundObjects.splice(indexBg, 1);
     }
     // /**

--- a/packages/webgal/src/Core/controller/stage/pixi/animations/testblur.ts
+++ b/packages/webgal/src/Core/controller/stage/pixi/animations/testblur.ts
@@ -10,7 +10,7 @@ export function generateTestblurAnimationObj(targetKey: string, duration: number
    * 在此书写为动画设置初态的操作
    */
   function setStartState() {
-    if (target) {
+    if (target?.pixiContainer) {
       target.pixiContainer.alpha = 0;
       // @ts-ignore
       target.pixiContainer.blur = 0;
@@ -22,7 +22,7 @@ export function generateTestblurAnimationObj(targetKey: string, duration: number
    * 在此书写为动画设置终态的操作
    */
   function setEndState() {
-    if (target) {
+    if (target?.pixiContainer) {
       target.pixiContainer.alpha = 1;
       // @ts-ignore
       target.pixiContainer.blur = 5;
@@ -40,9 +40,10 @@ export function generateTestblurAnimationObj(targetKey: string, duration: number
       const currentAddOplityDelta = (duration / baseDuration) * delta;
       const increasement = 1 / currentAddOplityDelta;
       const decreasement = 5 / currentAddOplityDelta;
-      if (container.alpha < 1) {
-        container.alpha += increasement;
-      }
+      if (container)
+        if (container.alpha < 1) {
+          container.alpha += increasement;
+        }
       // @ts-ignore
       if (container.blur < 5) {
         // @ts-ignore

--- a/packages/webgal/src/Core/controller/stage/pixi/animations/timeline.ts
+++ b/packages/webgal/src/Core/controller/stage/pixi/animations/timeline.ts
@@ -42,7 +42,6 @@ export function generateTimelineObj(
       times.push(currentDelay / duration);
     } else times.push(0);
   }
-  const container = target?.pixiContainer;
   let animateInstance: ReturnType<typeof popmotion.animate> | null = null;
   // 只有有 duration 的时候才有动画
   if (duration > 0) {
@@ -52,13 +51,13 @@ export function generateTimelineObj(
       duration,
       ease: easeArray,
       onUpdate: (updateValue) => {
-        if (container) {
+        if (target?.pixiContainer) {
           const { scaleX, scaleY, ...val } = updateValue;
           // @ts-ignore
-          PixiStage.assignTransform(container, omitBy(val, isUndefined));
+          PixiStage.assignTransform(target.pixiContainer, omitBy(val, isUndefined));
           // 因为 popmotion 不能用嵌套，scale 要手动设置
-          if (!isUndefined(scaleX)) container.scale.x = scaleX;
-          if (!isUndefined(scaleY)) container.scale.y = scaleY;
+          if (!isUndefined(scaleX)) target.pixiContainer.scale.x = scaleX;
+          if (!isUndefined(scaleY)) target.pixiContainer.scale.y = scaleY;
         }
       },
     });
@@ -77,13 +76,11 @@ export function generateTimelineObj(
       const assignValue = omitBy({ x: position.x, y: position.y, ...state }, isUndefined);
       // @ts-ignore
       PixiStage.assignTransform(target?.pixiContainer, assignValue);
-      if (target?.pixiContainer) {
-        if (!isUndefined(scale.x)) {
-          target.pixiContainer.scale.x = scale.x;
-        }
-        if (!isUndefined(scale?.y)) {
-          target.pixiContainer.scale.y = scale.y;
-        }
+      if (!isUndefined(scale.x)) {
+        target.pixiContainer.scale.x = scale.x;
+      }
+      if (!isUndefined(scale?.y)) {
+        target.pixiContainer.scale.y = scale.y;
       }
     }
   }
@@ -101,13 +98,11 @@ export function generateTimelineObj(
       const assignValue = omitBy({ x: position.x, y: position.y, ...state }, isUndefined);
       // @ts-ignore
       PixiStage.assignTransform(target?.pixiContainer, assignValue);
-      if (target?.pixiContainer) {
-        if (!isUndefined(scale.x)) {
-          target.pixiContainer.scale.x = scale.x;
-        }
-        if (!isUndefined(scale?.y)) {
-          target.pixiContainer.scale.y = scale.y;
-        }
+      if (!isUndefined(scale.x)) {
+        target.pixiContainer.scale.x = scale.x;
+      }
+      if (!isUndefined(scale?.y)) {
+        target.pixiContainer.scale.y = scale.y;
       }
     }
   }

--- a/packages/webgal/src/Core/controller/stage/pixi/animations/universalSoftIn.ts
+++ b/packages/webgal/src/Core/controller/stage/pixi/animations/universalSoftIn.ts
@@ -12,7 +12,7 @@ export function generateUniversalSoftInAnimationObj(targetKey: string, duration:
    */
   function setStartState() {
     elapsedTime = 0; // Reset timer when animation starts
-    if (target) {
+    if (target?.pixiContainer) {
       // 修正：不再强制设为 0，而是记录当前的透明度
       startAlpha = target.pixiContainer.alpha;
     }
@@ -22,7 +22,7 @@ export function generateUniversalSoftInAnimationObj(targetKey: string, duration:
    * 在此书写为动画设置终态的操作
    */
   function setEndState() {
-    if (target) {
+    if (target?.pixiContainer) {
       // 终态是完全不透明，这保持不变
       target.pixiContainer.alpha = 1;
     }
@@ -49,7 +49,7 @@ export function generateUniversalSoftInAnimationObj(targetKey: string, duration:
       // 公式：最终值 = 初始值 + (目标值 - 初始值) * 进度
       // 在这里，目标值是 1，所以公式为：
       // alpha = startAlpha + (1 - startAlpha) * easedProgress
-      sprite.alpha = startAlpha + (1 - startAlpha) * easedProgress;
+      if (sprite) sprite.alpha = startAlpha + (1 - startAlpha) * easedProgress;
     }
   }
 

--- a/packages/webgal/src/Core/controller/stage/pixi/animations/universalSoftOff.ts
+++ b/packages/webgal/src/Core/controller/stage/pixi/animations/universalSoftOff.ts
@@ -12,7 +12,7 @@ export function generateUniversalSoftOffAnimationObj(targetKey: string, duration
    */
   function setStartState() {
     elapsedTime = 0; // 重置计时器
-    if (target) {
+    if (target?.pixiContainer) {
       // 修正：不再强制设为1，而是记录当前的透明度
       startAlpha = target.pixiContainer.alpha;
     }
@@ -22,7 +22,7 @@ export function generateUniversalSoftOffAnimationObj(targetKey: string, duration
    * 在此书写为动画设置终态的操作
    */
   function setEndState() {
-    if (target) {
+    if (target?.pixiContainer) {
       // 终态是完全透明，这保持不变
       target.pixiContainer.alpha = 0;
     }
@@ -50,7 +50,7 @@ export function generateUniversalSoftOffAnimationObj(targetKey: string, duration
       // 在这里，目标值是 0，所以公式简化为：
       // alpha = startAlpha + (0 - startAlpha) * easedProgress
       // alpha = startAlpha * (1 - easedProgress)
-      targetContainer.alpha = startAlpha * (1 - easedProgress);
+      if (targetContainer) targetContainer.alpha = startAlpha * (1 - easedProgress);
     }
   }
 

--- a/packages/webgal/src/Core/gameScripts/changeBg/index.ts
+++ b/packages/webgal/src/Core/gameScripts/changeBg/index.ts
@@ -32,11 +32,18 @@ export const changeBg = (sentence: ISentence): IPerform => {
     dispatch(unlockCgInUserData({ name: unlockName, url, series }));
   }
 
-  /**
-   * 删掉相关 Effects，因为已经移除了
-   */
-  if (webgalStore.getState().stage.bgName !== sentence.content) {
+  // 检测 url 是否变化
+  let isUrlChanged = webgalStore.getState().stage.bgName !== sentence.content;
+  if (isUrlChanged) {
+    // 清除动画
+    WebGAL.gameplay.pixiStage?.removeAnimation('bg-main');
+    // 移除旧的 effect
     dispatch(stageActions.removeEffectByTargetId(`bg-main`));
+    // 标记旧的背景为退出中，防止旧背景继承新参数
+    const oldStageObject = WebGAL.gameplay.pixiStage?.getStageObjByKey('bg-main');
+    if (oldStageObject) {
+      oldStageObject.isExiting = true;
+    }
   }
 
   // 处理 transform 和 默认 transform

--- a/packages/webgal/src/Stage/MainStage/useSetFigure.ts
+++ b/packages/webgal/src/Stage/MainStage/useSetFigure.ts
@@ -63,7 +63,7 @@ export function useSetFigure(stageState: IStageState) {
   useEffect(() => {
     Object.entries(figureMetaData).forEach(([key, value]) => {
       const figureObject = WebGAL.gameplay.pixiStage?.getStageObjByKey(key);
-      if (figureObject && !figureObject.isExiting && value?.zIndex !== undefined) {
+      if (figureObject && !figureObject.isExiting && value?.zIndex !== undefined && figureObject.pixiContainer) {
         figureObject.pixiContainer.zIndex = value.zIndex;
       }
     });


### PR DESCRIPTION
# 介绍
修复舞台对象退场时, 有未完成的 hold 类型动画, 而导致 游戏卡死/动画缺失 的问题

# 主要更改
- 在 `changeBg` `changeFigure` url 变更时, 强制清除动画演出
- 优化了 `changeFigure` 对目标 id 的指定