### PR TITLE
fix: parser trim behavior

### DIFF
--- a/packages/parser/src/sceneParser.ts
+++ b/packages/parser/src/sceneParser.ts
@@ -29,7 +29,7 @@ export const sceneParser = (
   ADD_NEXT_ARG_LIST: commandType[],
   SCRIPT_CONFIG_MAP: ConfigMap,
 ): IScene => {
-  const rawSentenceList = rawScene.split('\n'); // 原始句子列表
+  const rawSentenceList = rawScene.replaceAll('\r', '').split('\n'); // 原始句子列表
 
   // 去分号留到后面去做了，现在注释要单独处理
   const rawSentenceListWithoutEmpty = rawSentenceList;

--- a/packages/parser/src/scriptParser/argsParser.ts
+++ b/packages/parser/src/scriptParser/argsParser.ts
@@ -23,10 +23,10 @@ export function argsParser(
   });
   rawArgsList.forEach((e) => {
     const equalSignIndex = e.indexOf('=');
-    let argName = e.slice(0, equalSignIndex);
-    let argValue: string | undefined = e.slice(equalSignIndex + 1);
+    let argName = e.slice(0, equalSignIndex).trim();
+    let argValue: string | undefined = e.slice(equalSignIndex + 1).trim();
     if (equalSignIndex < 0) {
-      argName = e;
+      argName = e.trim();
       argValue = undefined;
     }
     // 判断是不是语音参数

--- a/packages/parser/src/scriptParser/scriptParser.ts
+++ b/packages/parser/src/scriptParser/scriptParser.ts
@@ -36,14 +36,16 @@ export const scriptParser = (
   // 正式开始解析
 
   // 去分号
-  let newSentenceRaw = sentenceRaw.split(/(?<!\\);/)[0];
+  const commentSplit = sentenceRaw.split(/(?<!\\);/);
+  let newSentenceRaw = commentSplit[0].trim();
   newSentenceRaw = newSentenceRaw.replaceAll('\\;',';');
+  const sentenceComment = commentSplit[1] ?? '';
   if (newSentenceRaw === '') {
     // 注释提前返回
     return {
       command: commandType.comment, // 语句类型
       commandRaw: 'comment', // 命令原始内容，方便调试
-      content: sentenceRaw.split(';')[1] ?? '', // 语句内容
+      content: sentenceComment.trim(), // 语句内容
       args: [{ key: 'next', value: true }], // 参数列表
       sentenceAssets: [], // 语句携带的资源列表
       subScene: [], // 语句携带的子场景


### PR DESCRIPTION
# 介绍
- 修复用 `\n` 拆分文本时, 没有考虑到 `\r\n` 的问题
- 修复语句参数键值对没有修剪空格的问题 ( fix #737 )
- 修复 空行 和 仅带空格的行 会被视作 say 语句的问题
  - 现在它们会被视作注释
  - 非兼容更改

# 测试

``` js
changeBg:bg.webp -next;
changeFigure:1/open_eyes.webp -id=aaa;
;
label:loop;
;
setTransform: {"saturation":0} -next -target=aaa;
测试对话:正常情况是, 变灰的动画和这句话一起出现;
setTransform: {} -target=aaa -next -writeDefault; 
:恢复;
;
setTransform: {"saturation":0} -next  -target=aaa;
测试对话:next 后面多了一个空格;
setTransform: {} -target=aaa -next -writeDefault; 
:恢复;
;
setTransform: {"saturation":0} - next -target=aaa;
测试对话:next 前面多了一个空格;
setTransform: {} -target=aaa -next -writeDefault; 
:恢复;
;
setTransform: {"saturation":0} -next - target=aaa;
测试对话:target 前面多了一个空格;
setTransform: {} -target=aaa -next -writeDefault; 
:恢复;
;
setTransform: {"saturation":0} -next -target =aaa;
测试对话:target 后面多了一个空格;
setTransform: {} -target=aaa -next -writeDefault; 
:恢复;
;
setTransform: {"saturation":0} -next -target= aaa;
测试对话:target 的 = 后面多了一个空格;
setTransform: {} -target=aaa -next -writeDefault; 
:恢复;
;
setTransform: {"saturation":0} -next -target=aaa ;
测试对话:aaa(目标) 后面多了一个空格;
setTransform: {} -target=aaa -next -writeDefault; 
:恢复;
;
jumpLabel:loop;
```

``` js
label:loop;
测试对话测试对话测试对话测试对话测试对话测试对话:这是第一行字|这是第二行字|这是第三行字|这是第四行字|这是第五行字|这是第六行字;
;这是注释
 ;有空格的注释
;下面这一行有个空格
 
;下面这一行什么都没有

测试对话:这是一段话[这是一段话](ruby=156156153)这是一段话这是一段话这是一段话这是一段话这是一段话这是一段话这是一段话这是一段话;
jumpLabel:loop;
```