### PR TITLE
refactor: perform auto-import using import.meta.glob

### DIFF
--- a/packages/webgal/src/Core/util/pixiPerformManager/initRegister.ts
+++ b/packages/webgal/src/Core/util/pixiPerformManager/initRegister.ts
@@ -1,3 +1,1 @@
-import '../../gameScripts/pixi/performs/cherryBlossoms';
-import '../../gameScripts/pixi/performs/rain';
-import '../../gameScripts/pixi/performs/snow';
+import.meta.glob('../../gameScripts/pixi/performs/*.{ts,js,tsx,jsx}', { eager: true });

--- a/packages/webgal/vite.config.ts
+++ b/packages/webgal/vite.config.ts
@@ -1,10 +1,7 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import loadVersion from 'vite-plugin-package-version';
-import { resolve, relative } from 'path';
-import { visualizer } from 'rollup-plugin-visualizer';
-import { readdirSync, watch, writeFileSync } from 'fs';
-import { isEqual } from 'lodash';
+import { resolve } from 'path';
 import Info from 'unplugin-info/vite';
 import viteCompression from 'vite-plugin-compression';
 
@@ -13,40 +10,6 @@ import viteCompression from 'vite-plugin-compression';
 // @ts-ignore
 const env = process.env.NODE_ENV;
 console.log(env);
-(() => {
-  const pixiPerformScriptDirPath = './src/Core/gameScripts/pixi/performs/';
-  const pixiPerformManagerDirPath = './src/Core/util/pixiPerformManager/';
-  const relativePath = relative(pixiPerformManagerDirPath, pixiPerformScriptDirPath).replaceAll('\\', '/');
-  let lastFiles: string[] = [];
-
-  function setInitFile() {
-    console.log('正在自动编写pixi特效依赖注入');
-    writeFileSync(
-      resolve(pixiPerformManagerDirPath, 'initRegister.ts'),
-      lastFiles
-        .map((v) => {
-          const filePath = relativePath + '/' + v.slice(0, v.lastIndexOf('.'));
-          return `import '${filePath}';`;
-        })
-        .join('\n') + '\n',
-      { encoding: 'utf-8' },
-    );
-  }
-
-  function getPixiPerformScriptFiles() {
-    const pixiPerformScriptFiles = readdirSync(pixiPerformScriptDirPath, { encoding: 'utf-8' }).filter((v) =>
-      ['ts', 'js', 'tsx', 'jsx'].includes(v.slice(v.indexOf('.') + 1, v.length)),
-    );
-    if (!isEqual(pixiPerformScriptFiles, lastFiles)) {
-      lastFiles = pixiPerformScriptFiles;
-      setInitFile();
-    }
-  }
-
-  getPixiPerformScriptFiles();
-
-  if (env !== 'production') watch(pixiPerformScriptDirPath, { encoding: 'utf-8' }, getPixiPerformScriptFiles);
-})();
 
 export default defineConfig({
   plugins: [


### PR DESCRIPTION
替换 #738 ，使用import.meta.glob代替自定义编译流程，简洁稳定，意图清晰