### PR TITLE
fix: parse argument when say content is blank

### DIFF
--- a/packages/parser/src/scriptParser/scriptParser.ts
+++ b/packages/parser/src/scriptParser/scriptParser.ts
@@ -37,10 +37,10 @@ export const scriptParser = (
 
   // 去分号
   const commentSplit = sentenceRaw.split(/(?<!\\);/);
-  let newSentenceRaw = commentSplit[0].trim();
+  let newSentenceRaw = commentSplit[0];
   newSentenceRaw = newSentenceRaw.replaceAll('\\;',';');
   const sentenceComment = commentSplit[1] ?? '';
-  if (newSentenceRaw === '') {
+  if (newSentenceRaw.trim() === '') {
     // 注释提前返回
     return {
       command: commandType.comment, // 语句类型


### PR DESCRIPTION
# 介绍
修复连续对话为空时, 第一个参数会被当做内容的问题
<img width="336" height="180" alt="image" src="https://github.com/user-attachments/assets/434130c3-a872-4af9-89f6-a7a857129371" />

```js
label:loop;
测试对话测试对话测试对话测试对话测试对话测试对话:这是第一行字|这是第二行字|这是第三行字|这是第四行字|这是第五行字|这是第六行字;
;这是注释
 ;有空格的注释
;下面这一行有个空格
 
;下面这一行什么都没有

;如果有参数, 应该作为say
 -arg=123;
测试对话:这是一段话[这是一段话](ruby=156156153)这是一段话这是一段话这是一段话这是一段话这是一段话这是一段话这是一段话这是一段话;
jumpLabel:loop;
```