### PR TITLE
feat: add rules argument for getUserInput

### DIFF
--- a/packages/webgal/src/Core/gameScripts/getUserInput/index.tsx
+++ b/packages/webgal/src/Core/gameScripts/getUserInput/index.tsx
@@ -47,7 +47,7 @@ export const getUserInput = (sentence: ISentence): IPerform => {
             if (rule) {
               const reg = tryToRegex(rule, ruleFlag);
               if (reg && !reg.test(userInput.value)) {
-                if (ruleText) alert(ruleText);
+                if (ruleText) alert(ruleText.replaceAll(/\$0/g, userInput.value));
                 return;
               }
               if (!reg) {

--- a/packages/webgal/src/Core/gameScripts/getUserInput/index.tsx
+++ b/packages/webgal/src/Core/gameScripts/getUserInput/index.tsx
@@ -13,6 +13,8 @@ import { getStringArgByKey } from '@/Core/util/getSentenceArg';
 import { nextSentence } from '@/Core/controller/gamePlay/nextSentence';
 import { setStageVar } from '@/store/stageReducer';
 import { getCurrentFontFamily } from '@/hooks/useFontFamily';
+import { logger } from '@/Core/util/logger';
+import { tryToRegex } from '@/Core/util/global';
 
 /**
  * 显示选择枝
@@ -26,6 +28,9 @@ export const getUserInput = (sentence: ISentence): IPerform => {
   let buttonText = getStringArgByKey(sentence, 'buttonText') ?? '';
   buttonText = buttonText === '' ? 'OK' : buttonText;
   const defaultValue = getStringArgByKey(sentence, 'defaultValue');
+  const rule = getStringArgByKey(sentence, 'rule');
+  const ruleFlag = getStringArgByKey(sentence, 'ruleFlag');
+  const ruleText = getStringArgByKey(sentence, 'ruleText');
 
   const font = getCurrentFontFamily();
 
@@ -39,6 +44,16 @@ export const getUserInput = (sentence: ISentence): IPerform => {
           onMouseEnter={playSeEnter}
           onClick={() => {
             const userInput: HTMLInputElement = document.getElementById('user-input') as HTMLInputElement;
+            if (rule) {
+              const reg = tryToRegex(rule, ruleFlag);
+              if (reg && !reg.test(userInput.value)) {
+                if (ruleText) alert(ruleText);
+                return;
+              }
+              if (!reg) {
+                logger.warn(`getUserInput: rule ${rule} is not a valid regex`);
+              }
+            }
             if (userInput) {
               webgalStore.dispatch(
                 setStageVar({

--- a/packages/webgal/src/Core/gameScripts/getUserInput/index.tsx
+++ b/packages/webgal/src/Core/gameScripts/getUserInput/index.tsx
@@ -15,6 +15,7 @@ import { setStageVar } from '@/store/stageReducer';
 import { getCurrentFontFamily } from '@/hooks/useFontFamily';
 import { logger } from '@/Core/util/logger';
 import { tryToRegex } from '@/Core/util/global';
+import { showGlogalDialog } from '@/UI/GlobalDialog/GlobalDialog';
 
 /**
  * 显示选择枝
@@ -47,7 +48,11 @@ export const getUserInput = (sentence: ISentence): IPerform => {
             if (rule) {
               const reg = tryToRegex(rule, ruleFlag);
               if (reg && !reg.test(userInput.value)) {
-                if (ruleText) alert(ruleText.replaceAll(/\$0/g, userInput.value));
+                if (ruleText)
+                  showGlogalDialog({
+                    title: ruleText.replaceAll(/\$0/g, userInput.value),
+                    leftText: 'OK',
+                  });
                 return;
               }
               if (!reg) {

--- a/packages/webgal/src/Core/gameScripts/getUserInput/index.tsx
+++ b/packages/webgal/src/Core/gameScripts/getUserInput/index.tsx
@@ -32,6 +32,7 @@ export const getUserInput = (sentence: ISentence): IPerform => {
   const rule = getStringArgByKey(sentence, 'rule');
   const ruleFlag = getStringArgByKey(sentence, 'ruleFlag');
   const ruleText = getStringArgByKey(sentence, 'ruleText');
+  const ruleButtonText = getStringArgByKey(sentence, 'ruleButtonText') ?? 'OK';
 
   const font = getCurrentFontFamily();
 
@@ -51,7 +52,7 @@ export const getUserInput = (sentence: ISentence): IPerform => {
                 if (ruleText)
                   showGlogalDialog({
                     title: ruleText.replaceAll(/\$0/g, userInput.value),
-                    leftText: 'OK',
+                    leftText: ruleButtonText,
                   });
                 return;
               }

--- a/packages/webgal/src/Core/util/global.ts
+++ b/packages/webgal/src/Core/util/global.ts
@@ -1,0 +1,7 @@
+export function tryToRegex(str: string, flag: string | null): RegExp | false {
+  try {
+    return new RegExp(str, flag || '');
+  } catch (e) {
+    return false;
+  }
+}

--- a/packages/webgal/src/UI/GlobalDialog/GlobalDialog.tsx
+++ b/packages/webgal/src/UI/GlobalDialog/GlobalDialog.tsx
@@ -12,7 +12,7 @@ export default function GlobalDialog() {
 
 interface IShowGlobalDialogProps {
   title: string;
-  leftText?: string;
+  leftText: string;
   rightText?: string;
   leftFunc?: Function;
   rightFunc?: Function;

--- a/packages/webgal/src/UI/GlobalDialog/GlobalDialog.tsx
+++ b/packages/webgal/src/UI/GlobalDialog/GlobalDialog.tsx
@@ -12,10 +12,10 @@ export default function GlobalDialog() {
 
 interface IShowGlobalDialogProps {
   title: string;
-  leftText: string;
-  rightText: string;
-  leftFunc: Function;
-  rightFunc: Function;
+  leftText?: string;
+  rightText?: string;
+  leftFunc?: Function;
+  rightFunc?: Function;
 }
 
 export function showGlogalDialog(props: IShowGlobalDialogProps) {
@@ -23,12 +23,12 @@ export function showGlogalDialog(props: IShowGlobalDialogProps) {
   webgalStore.dispatch(setVisibility({ component: 'showGlobalDialog', visibility: true }));
   const handleLeft = () => {
     playSeClick();
-    props.leftFunc();
+    props.leftFunc?.();
     hideGlobalDialog();
   };
   const handleRight = () => {
     playSeClick();
-    props.rightFunc();
+    props.rightFunc?.();
     hideGlobalDialog();
   };
   const renderElement = (
@@ -37,12 +37,16 @@ export function showGlogalDialog(props: IShowGlobalDialogProps) {
         <div className={styles.glabalDialog_container_inner}>
           <div className={styles.title}>{props.title}</div>
           <div className={styles.button_list}>
-            <div className={styles.button} onClick={handleLeft} onMouseEnter={playSeEnter}>
-              {props.leftText}
-            </div>
-            <div className={styles.button} onClick={handleRight} onMouseEnter={playSeEnter}>
-              {props.rightText}
-            </div>
+            {props.leftText && (
+              <div className={styles.button} onClick={handleLeft} onMouseEnter={playSeEnter}>
+                {props.leftText}
+              </div>
+            )}
+            {props.rightText && (
+              <div className={styles.button} onClick={handleRight} onMouseEnter={playSeEnter}>
+                {props.rightText}
+              </div>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
为`getUserInput`添加正则验证功能参数

新增参数：

- **rule**：校验规则，这里的输入将会被视作为一个正则表达式
- **ruleFlag**：标识，如：`g`,`i`等
- **ruleText**：校验不通过时提示弹窗的文本，可用$0获取输入的文本
-  **ruleButtonText**：校验不通过时提示弹窗的按钮文本

写法示例：
```
getUserInput:name -title=如何称呼你 -buttonText=确认 -rule=^.{1,2}$ -ruleText=$0不符合1-2个字符;
WebGAL:很高兴遇见你，{name}！
````

当正则出现错误时，会跳过验证，并在控制台打印信息
<img width="655" height="49" alt="image" src="https://github.com/user-attachments/assets/aa1296aa-b434-4eeb-9ba9-556463e83b6d" />

当正则不通过时，且填写了`-ruleText`参数时：
<img width="1910" height="873" alt="image" src="https://github.com/user-attachments/assets/5fb469d6-cb68-41e1-95be-137703933d7c" />

close #769 #782 

