### PR TITLE
fix: set logo background opaque when fade in

### DIFF
--- a/packages/webgal/src/UI/Logo/logo.module.scss
+++ b/packages/webgal/src/UI/Logo/logo.module.scss
@@ -50,6 +50,9 @@
   0%{
     opacity: 1;
   }
+  65%{
+    opacity: 1;
+  }
   99%{
     opacity: 0;
   }


### PR DESCRIPTION
#823

> 基本上已经在 issue 中把改动点说明了，这里直接复制黏贴一下。

---

在切换最后一张 Logo 图片（如果有复数的话）的渐入过程中，能隐约看到主页面，这应该是不符合预期的。直接使用本仓库的模板就能直接复现这个问题。

下面有一个演示目前问题的 gif，如果加载不出来可以点击[链接](https://picgo-camille-freetry.oss-cn-beijing.aliyuncs.com/img/logo_case_before.gif)下载查看。

![logo_case_before](https://picgo-camille-freetry.oss-cn-beijing.aliyuncs.com/img/logo_case_before.gif)

从渐入渐出的实现上看，在 Logo 图片渐入的过程中，白底背景就开始渐出，使得在 0% ～ 35% 这段动画中，会有一小段时间 Logo 层是半透明的，可以隐约看到主页面。

```scss 
@keyframes change-img-anim {
  0%{
    opacity: 0;
  }
  35%{
    opacity: 1;
  }
  65%{
    opacity: 1;
  }
  99%{
    opacity: 0;
  }
  100%{
    opacity: 0;
    display: none;
  }
}

@keyframes fadeout {
  0%{
    opacity: 1;
  }
  99%{
    opacity: 0;
  }
  100%{
    opacity: 0;
    display: none;
  }
}
```

我的想法是让白底背景在 Logo 图片渐入的过程中保持不透明，不知道这样修复是否合适。

```diff
@keyframes change-img-anim {
  0%{
    opacity: 0;
  }
  35%{
    opacity: 1;
  }
  65%{
    opacity: 1;
  }
  99%{
    opacity: 0;
  }
  100%{
    opacity: 0;
    display: none;
  }
}

@keyframes fadeout {
  0%{
    opacity: 1;
  }
+  65%{
+    opacity: 1;
+  }
  99%{
    opacity: 0;
  }
  100%{
    opacity: 0;
    display: none;
  }
}
```

下面有一个演示修复后效果的 gif，如果加载不出来可以点击[链接](https://picgo-camille-freetry.oss-cn-beijing.aliyuncs.com/img/logo_case_after.gif)下载查看。

![logo_case_after](https://picgo-camille-freetry.oss-cn-beijing.aliyuncs.com/img/logo_case_after.gif)