### PR TITLE
fix: 修复 changeBg 与 changeFigure 的 exit 设置不能正常生效的问题

### DIFF
--- a/packages/webgal/src/Core/Modules/animationFunctions.ts
+++ b/packages/webgal/src/Core/Modules/animationFunctions.ts
@@ -13,6 +13,7 @@ import {
   DEFAULT_FIG_IN_DURATION,
   DEFAULT_FIG_OUT_DURATION,
 } from '../constants';
+import { stageActions } from '@/store/stageReducer';
 
 // eslint-disable-next-line max-params
 export function getAnimationObject(animationName: string, target: string, duration: number, writeDefault: boolean) {
@@ -102,6 +103,9 @@ export function getEnterExitAnimation(
       logger.debug('取代默认退出动画', target);
       animation = getAnimationObject(animationName, realTarget ?? target, getAnimateDuration(animationName), false);
       duration = getAnimateDuration(animationName);
+      // 退出动画拿完后，删了这个设定
+      webgalStore.dispatch(stageActions.removeAnimationSettingsByTargetOff(target));
+      logger.debug('删除退出动画设定', target);
     }
     return { duration, animation };
   }

--- a/packages/webgal/src/Core/gameScripts/changeFigure.ts
+++ b/packages/webgal/src/Core/gameScripts/changeFigure.ts
@@ -155,6 +155,10 @@ export function changeFigure(sentence: ISentence): IPerform {
     }
   }
   const setAnimationNames = (key: string, sentence: ISentence) => {
+    // 如果立绘被关闭了，那么就不用设置了
+    if (content === '') {
+      return;
+    }
     // 处理 transform 和 默认 transform
     let animationObj: AnimationFrame[];
     if (transformString) {

--- a/packages/webgal/src/store/stageReducer.ts
+++ b/packages/webgal/src/store/stageReducer.ts
@@ -159,19 +159,29 @@ const stageSlice = createSlice({
         const prev = state.animationSettings[index];
         state.animationSettings.splice(index, 1);
 
-        const prevTarget = `${action.payload}-off`;
-        const prevSetting = {
-          ...prev,
-          target: prevTarget,
-        };
+        if (prev.exitAnimationName) {
+          // 如果有退出动画设定，保留一个 -off 的设定
+          const prevTarget = `${action.payload}-off`;
+          const prevSetting = {
+            ...prev,
+            target: prevTarget,
+          };
 
-        const prevIndex = state.animationSettings.findIndex((a) => a.target === prevTarget);
+          const prevIndex = state.animationSettings.findIndex((a) => a.target === prevTarget);
 
-        if (prevIndex >= 0) {
-          state.animationSettings.splice(prevIndex, 1, prevSetting);
-        } else {
-          state.animationSettings.push(prevSetting);
+          if (prevIndex >= 0) {
+            state.animationSettings.splice(prevIndex, 1, prevSetting);
+          } else {
+            state.animationSettings.push(prevSetting);
+          }
         }
+      }
+    },
+    removeAnimationSettingsByTargetOff: (state, action: PayloadAction<string>) => {
+      // 这里不加 -off 因为传入的就是带 -off 的
+      const index = state.animationSettings.findIndex((a) => a.target === `${action.payload}`);
+      if (index >= 0) {
+        state.animationSettings.splice(index, 1);
       }
     },
     addPerform: (state, action: PayloadAction<IRunPerform>) => {


### PR DESCRIPTION
# 背景

目前的 bg 和 figure 的 exit 动画设置都不能正常生效，如果想正常生效，需要在下一个 changeBg 或 changeFigure 设置相同的 exit 动画（用 setTransition 也一样），最小复现示例（替换 `start.txt` 即可）：

```text
changeBg:bg.webp -exit=shake -next;

changeFigure:stand.webp -left -enter=enter-from-left -exit=shake -next;
:点击测试;
changeFigure:none -left -next;
:退场特效应为 shake，实际为 exit;

changeFigure:stand.webp -left -enter=enter-from-left -next;
:点击测试;
changeFigure:none -exit=shake -left -next;
:退场特效应为 exit，实际为 shake;

:点击测试;
changeBg:none -next;
:退场特效应为 shake，实际为 exit;

changeBg:bg.webp -next;
:点击测试;
changeBg:none -next -exit=shake;
:退场特效应为 exit，实际为 shake;

end;
```

# 问题排查 & 修复思路

> bg 和 figure 用的是相同的逻辑，这里以 bg 为例展开

核心问题是目前的 bg 和 figure 的切换依赖于相关的状态：“旧bg”的设定在相关指令中就被清除了，取而代之的是“新bg”的设定，在这些状态变更后，才依次执行“旧bg”的 exit 与“新bg” 的 enter，故两者在 `getEnterExitAnimation` 时拿到的都是“新bg”的设定。

https://github.com/OpenWebGAL/WebGAL/blob/23e98d9f2638d0f478c4a5819d57cc175025015f/packages/webgal/src/Core/gameScripts/changeBg/index.ts#L49

修复思路是将原先的仅移除操作改为在移除的同时，使用 `${target}-off` 存储“旧bg”的设定（重复设定时移除之前的设定），保证在 exit 中能拿到“旧bg”的设定。

# 测试

使用最小复现示例的 txt 文件就可以进行测试。

这个修改方案的缺点是会往状态里增加一倍的 animationSetting，但是想不到别的更好的方案了。