### PR TITLE
fix: init config data when clear all data

### DIFF
--- a/packages/webgal/src/Core/util/coreInitialFunction/infoFetcher.ts
+++ b/packages/webgal/src/Core/util/coreInitialFunction/infoFetcher.ts
@@ -1,5 +1,5 @@
 import { webgalStore } from '@/store/store';
-import { setGlobalVar } from '@/store/userDataReducer';
+import { setGlobalVar, setUserData } from '@/store/userDataReducer';
 import { setEnableAppreciationMode } from '@/store/GUIReducer';
 import { Live2D, WebGAL } from '@/Core/WebGAL';
 import { WebgalParser } from '@/Core/parser/sceneParser';
@@ -71,7 +71,7 @@ export const infoFetcher = (url: string) => {
       }
     });
 
-    window.gameConfigInit = gameConfigInit;
+    dispatch(setUserData({ key: 'gameConfigInit', value: gameConfigInit }));
     // @ts-expect-error renderPromiseResolve is a global variable
     window.renderPromiseResolve();
     setStorage();

--- a/packages/webgal/src/store/userDataInterface.ts
+++ b/packages/webgal/src/store/userDataInterface.ts
@@ -90,6 +90,7 @@ export interface IUserData {
   globalGameVar: IGameVar; // 不跟随存档的全局变量
   optionData: IOptionData; // 用户设置选项数据
   appreciationData: IAppreciation;
+  gameConfigInit: IGameVar;
 }
 
 export interface ISetUserDataPayload {

--- a/packages/webgal/src/store/userDataReducer.ts
+++ b/packages/webgal/src/store/userDataReducer.ts
@@ -46,6 +46,7 @@ export const initState: IUserData = {
     bgm: [],
     cg: [],
   },
+  gameConfigInit: {},
 };
 
 const userDataSlice = createSlice({
@@ -138,7 +139,8 @@ const userDataSlice = createSlice({
       Object.assign(state.optionData, initialOptionSet);
     },
     resetAllData(state) {
-      Object.assign(state, { ...cloneDeep(initState), globalGameVar: cloneDeep(window.gameConfigInit || {}) });
+      const { gameConfigInit } = state;
+      Object.assign(state, { ...cloneDeep(initState), globalGameVar: cloneDeep(gameConfigInit), gameConfigInit });
     },
   },
 });

--- a/packages/webgal/src/types/global.ts
+++ b/packages/webgal/src/types/global.ts
@@ -1,9 +1,0 @@
-import { IGameVar } from '@/store/stageInterface';
-
-export {};
-
-declare global {
-  interface Window {
-    gameConfigInit?: IGameVar;
-  }
-}


### PR DESCRIPTION
## 背景

目前如果在剧本中使用了 config.txt 的配置数据，在清空所有数据后，这些配置相关的全局变量将获取不到值，最小复现示例（`start.txt`）：

```text
{Game_name}

end;
```

## 问题排查 & 解决方案

目前“清空所有数据”的操作会直接将配置数据清空，对于导出的游戏，得重启游戏这些配置才能重新获取到值；本地调试的话，得重新启动项目才行，刷新页面有概率能行。

> 可以修改的原始配置变量 `Title_img`、`Title_bgm`、`Game_name`、`Game_key`。想要恢复则可以在游戏选项中使用清空所有数据即可恢复。

官方文档里有这么一句话，显然现在的效果是不符合预期的。解决方案是在 config.txt 的配置初始化时，同时存一份临时数据在某个地方（window 等），这里直接选择存在 window 上，然后在执行“清空所有数据”的操作时，将这份初始化配置与默认配置一并写入。

测试用例：

```text
{Game_name}

setVar:Game_name=new Game Name -global;

{Game_name}

end;
```