### PR TITLE
fix: resume alpha filter

### DIFF
--- a/packages/webgal/src/Core/Modules/animationFunctions.ts
+++ b/packages/webgal/src/Core/Modules/animationFunctions.ts
@@ -29,7 +29,7 @@ export function getAnimationObject(animationName: string, target: string, durati
         newEffect = cloneDeep({ ...baseTransform, duration: 0, ease: '' });
       }
 
-      PixiStage.assignTransform(newEffect, effect);
+      PixiStage.assignTransform(newEffect, effect, false);
       newEffect.duration = effect.duration;
       newEffect.ease = effect.ease;
       return newEffect;

--- a/packages/webgal/src/Core/controller/stage/pixi/PixiController.ts
+++ b/packages/webgal/src/Core/controller/stage/pixi/PixiController.ts
@@ -67,12 +67,19 @@ window.PIXI = PIXI;
 INSTALLED.push(GifResource);
 
 export default class PixiStage {
-  public static assignTransform<T extends ITransform>(target: T, source?: ITransform) {
+  public static assignTransform<T extends ITransform>(target: T, source?: ITransform, convertAlpha = true) {
     if (!source) return;
     const targetScale = target.scale;
     const targetPosition = target.position;
     if (target.scale) Object.assign(targetScale, source.scale);
     if (target.position) Object.assign(targetPosition, source.position);
+    if (convertAlpha) {
+      const sourceAlpha = source.alpha;
+      if (sourceAlpha !== undefined) {
+        source.alpha = 1;
+        (source as any).alphaFilterVal = sourceAlpha;
+      }
+    }
     Object.assign(target, source);
     target.scale = targetScale;
     target.position = targetPosition;

--- a/packages/webgal/src/Core/controller/stage/pixi/WebGALPixiContainer.ts
+++ b/packages/webgal/src/Core/controller/stage/pixi/WebGALPixiContainer.ts
@@ -333,9 +333,18 @@ export class WebGALPixiContainer extends PIXI.Container {
 
   private baseX = 0;
   private baseY = 0;
+  private alphaFilter = new PIXI.filters.AlphaFilter(1);
 
   public constructor() {
     super();
+    this.addInternalFilterInstance(this.alphaFilter);
+  }
+
+  public get alphaFilterVal(): number {
+    return this.alphaFilter.alpha;
+  }
+  public set alphaFilterVal(v: number) {
+    this.alphaFilter.alpha = v;
   }
 
   public removeFilterByName(filterName: string) {
@@ -622,6 +631,10 @@ export class WebGALPixiContainer extends PIXI.Container {
       let insertIndex = this.filters.length;
       for (let i = 0; i < this.filters.length; i++) {
         const currentFilter = this.filters[i]!;
+        if (currentFilter === this.alphaFilter) {
+          insertIndex = i;
+          break;
+        }
         const currentName = this.filterToName.get(currentFilter);
         if (currentName) {
           const currentPriority = FILTER_CONFIGS[currentName]?.priority ?? 0;
@@ -650,5 +663,13 @@ export class WebGALPixiContainer extends PIXI.Container {
     inst = cfg.create() as T;
     this.insertFilterWithPriority(filterName, inst);
     return inst;
+  }
+
+  private addInternalFilterInstance(filter: PIXI.Filter): void {
+    if (!this.filters) {
+      this.filters = [filter];
+    } else {
+      this.filters.push(filter);
+    }
   }
 }

--- a/packages/webgal/src/Core/controller/stage/pixi/animations/timeline.ts
+++ b/packages/webgal/src/Core/controller/stage/pixi/animations/timeline.ts
@@ -19,9 +19,6 @@ export function generateTimelineObj(
   targetKey: string,
   duration: number,
 ): IAnimationObject {
-  for (const segment of timeline) {
-    // Alpha 现在直接使用原生属性，无需转换为 alphaFilterVal
-  }
   const target = WebGAL.gameplay.pixiStage!.getStageObjByKey(targetKey);
   let currentDelay = 0;
   const values = [];

--- a/packages/webgal/src/Core/controller/stage/pixi/animations/universalSoftIn.ts
+++ b/packages/webgal/src/Core/controller/stage/pixi/animations/universalSoftIn.ts
@@ -14,7 +14,7 @@ export function generateUniversalSoftInAnimationObj(targetKey: string, duration:
     elapsedTime = 0; // Reset timer when animation starts
     if (target?.pixiContainer) {
       // 修正：不再强制设为 0，而是记录当前的透明度
-      startAlpha = target.pixiContainer.alpha;
+      startAlpha = target.pixiContainer.alphaFilterVal;
     }
   }
 
@@ -24,7 +24,7 @@ export function generateUniversalSoftInAnimationObj(targetKey: string, duration:
   function setEndState() {
     if (target?.pixiContainer) {
       // 终态是完全不透明，这保持不变
-      target.pixiContainer.alpha = 1;
+      target.pixiContainer.alphaFilterVal = 1;
     }
   }
 
@@ -49,7 +49,7 @@ export function generateUniversalSoftInAnimationObj(targetKey: string, duration:
       // 公式：最终值 = 初始值 + (目标值 - 初始值) * 进度
       // 在这里，目标值是 1，所以公式为：
       // alpha = startAlpha + (1 - startAlpha) * easedProgress
-      if (sprite) sprite.alpha = startAlpha + (1 - startAlpha) * easedProgress;
+      if (sprite) sprite.alphaFilterVal = startAlpha + (1 - startAlpha) * easedProgress;
     }
   }
 

--- a/packages/webgal/src/Core/controller/stage/pixi/animations/universalSoftOff.ts
+++ b/packages/webgal/src/Core/controller/stage/pixi/animations/universalSoftOff.ts
@@ -14,7 +14,7 @@ export function generateUniversalSoftOffAnimationObj(targetKey: string, duration
     elapsedTime = 0; // 重置计时器
     if (target?.pixiContainer) {
       // 修正：不再强制设为1，而是记录当前的透明度
-      startAlpha = target.pixiContainer.alpha;
+      startAlpha = target.pixiContainer.alphaFilterVal;
     }
   }
 
@@ -24,7 +24,7 @@ export function generateUniversalSoftOffAnimationObj(targetKey: string, duration
   function setEndState() {
     if (target?.pixiContainer) {
       // 终态是完全透明，这保持不变
-      target.pixiContainer.alpha = 0;
+      target.pixiContainer.alphaFilterVal = 0;
     }
   }
 
@@ -50,7 +50,7 @@ export function generateUniversalSoftOffAnimationObj(targetKey: string, duration
       // 在这里，目标值是 0，所以公式简化为：
       // alpha = startAlpha + (0 - startAlpha) * easedProgress
       // alpha = startAlpha * (1 - easedProgress)
-      if (targetContainer) targetContainer.alpha = startAlpha * (1 - easedProgress);
+      if (targetContainer) targetContainer.alphaFilterVal = startAlpha * (1 - easedProgress);
     }
   }
 


### PR DESCRIPTION
# 介绍

恢复 alphaFilterVal ，即之前的 alpha 滤镜方案。

您可能会注意到我没有恢复 setEffect 以前转化 alpha 的逻辑，因为我实际测试它反而会有点问题，只要保证 updateEffect 之前处理好应该就行。 我检查了所有 updateEffect ，应该是不会出问题的。

fix #829 
- 我排查了很久，最终直到 bevelFilter 里打印属性都是没有问题的，那么问题只可能出在 uSampler 缺失，我有点怀疑又是 pixi container alpha 整活，至少恢复到滤镜方案后，我再没测出类似问题

fix #830
- pixi container alpha 为 0 时不调用 _render，因此动作表情，还要其他的一些东西都没有得到更新。

fix #831 
- 因为pixi container alpha 在前，影响了泛光滤镜的输入，在最后才应用 alpha 滤镜可以规避这个问题。
