### PR TITLE
fix: failed to modify source transform

### DIFF
--- a/packages/webgal/src/Core/controller/stage/pixi/PixiController.ts
+++ b/packages/webgal/src/Core/controller/stage/pixi/PixiController.ts
@@ -73,16 +73,16 @@ export default class PixiStage {
     const targetPosition = target.position;
     if (target.scale) Object.assign(targetScale, source.scale);
     if (target.position) Object.assign(targetPosition, source.position);
-    if (convertAlpha) {
-      const sourceAlpha = source.alpha;
-      if (sourceAlpha !== undefined) {
-        source.alpha = 1;
-        (source as any).alphaFilterVal = sourceAlpha;
-      }
-    }
     Object.assign(target, source);
     target.scale = targetScale;
     target.position = targetPosition;
+    if (convertAlpha) {
+      const sourceAlpha = source.alpha;
+      if (sourceAlpha !== undefined) {
+        target.alpha = 1;
+        (target as any).alphaFilterVal = sourceAlpha;
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
# 介绍

#832 后，在编辑器那边预览的时候，有几率卡死并触发以下错误。

<img width="668" height="389" alt="image" src="https://github.com/user-attachments/assets/bc8d4620-c51c-4af7-978b-1e8b4ec51659" />

cloneDeep一下似乎就好了