### PR TITLE
fix: update appreciation data properly

### DIFF
--- a/packages/webgal/src/Core/gameScripts/bgm.ts
+++ b/packages/webgal/src/Core/gameScripts/bgm.ts
@@ -4,6 +4,8 @@ import { playBgm } from '@/Core/controller/stage/playBgm';
 import { getNumberArgByKey, getStringArgByKey } from '@/Core/util/getSentenceArg';
 import { webgalStore } from '@/store/store';
 import { unlockBgmInUserData } from '@/store/userDataReducer';
+import localforage from 'localforage';
+import { WebGAL } from '../WebGAL';
 
 /**
  * 播放一段bgm
@@ -20,6 +22,8 @@ export const bgm = (sentence: ISentence): IPerform => {
 
   if (name !== '') {
     webgalStore.dispatch(unlockBgmInUserData({ name, url, series }));
+    const userDataState = webgalStore.getState().userData;
+    localforage.setItem(WebGAL.gameKey, userDataState).then(() => {});
   }
 
   playBgm(url, enter, volume);

--- a/packages/webgal/src/Core/gameScripts/changeBg/index.ts
+++ b/packages/webgal/src/Core/gameScripts/changeBg/index.ts
@@ -14,6 +14,7 @@ import cloneDeep from 'lodash/cloneDeep';
 import { getAnimateDuration } from '@/Core/Modules/animationFunctions';
 import { WebGAL } from '@/Core/WebGAL';
 import { DEFAULT_BG_OUT_DURATION } from '@/Core/constants';
+import localforage from 'localforage';
 
 /**
  * 进行背景图片的切换
@@ -34,6 +35,8 @@ export const changeBg = (sentence: ISentence): IPerform => {
   const dispatch = webgalStore.dispatch;
   if (unlockName !== '') {
     dispatch(unlockCgInUserData({ name: unlockName, url, series }));
+    const userDataState = webgalStore.getState().userData;
+    localforage.setItem(WebGAL.gameKey, userDataState).then(() => {});
   }
 
   /**

--- a/packages/webgal/src/store/userDataReducer.ts
+++ b/packages/webgal/src/store/userDataReducer.ts
@@ -69,7 +69,7 @@ const userDataSlice = createSlice({
       state.appreciationData.cg.forEach((e) => {
         if (url === e.url) {
           isExist = true;
-          e.url = url;
+          e.name = name;
           e.series = series;
         }
       });
@@ -84,7 +84,7 @@ const userDataSlice = createSlice({
       state.appreciationData.bgm.forEach((e) => {
         if (url === e.url) {
           isExist = true;
-          e.url = url;
+          e.name = name;
           e.series = series;
         }
       });


### PR DESCRIPTION
# 介绍

- 修复 changeBg 和 bgm 的解锁鉴赏不会立即生效，得需要刷新游戏才能在鉴赏里看到的问题。（unlockCg 和 unlockBgm 倒是没这个问题）
- 修复解锁同 url 的鉴赏时，名称没有被更新的问题。（原来的 url 左手倒右手应该是逻辑错误吧）
