### PR TITLE
feat: add blend mode argument

### DIFF
--- a/packages/webgal/src/Core/controller/stage/pixi/PixiController.ts
+++ b/packages/webgal/src/Core/controller/stage/pixi/PixiController.ts
@@ -568,6 +568,9 @@ export default class PixiStage {
       if (metadata.zIndex) {
         thisFigureContainer.zIndex = metadata.zIndex;
       }
+      if (metadata.blendMode) {
+        thisFigureContainer.blendMode = metadata.blendMode;
+      }
     }
     // 挂载
     this.figureContainer.addChild(thisFigureContainer);
@@ -663,6 +666,9 @@ export default class PixiStage {
       if (metadata) {
         if (metadata.zIndex) {
           thisFigureContainer.zIndex = metadata.zIndex;
+        }
+        if (metadata.blendMode) {
+          thisFigureContainer.blendMode = metadata.blendMode;
         }
       }
       // 挂载

--- a/packages/webgal/src/Core/controller/stage/pixi/WebGALPixiContainer.ts
+++ b/packages/webgal/src/Core/controller/stage/pixi/WebGALPixiContainer.ts
@@ -9,6 +9,7 @@ import { BevelFilter } from '@/Core/controller/stage/pixi/shaders/BevelFilter';
 import * as PIXI from 'pixi.js';
 import { BlurFilter } from '@pixi/filter-blur';
 import { INIT_RAD, RadiusAlphaFilter } from '@/Core/controller/stage/pixi/shaders/RadiusAlphaFilter';
+import { logger } from '@/Core/util/logger';
 
 /**
  * Filter configuration for creation and default state detection.
@@ -347,6 +348,40 @@ export class WebGALPixiContainer extends PIXI.Container {
     this.alphaFilter.alpha = v;
   }
 
+  public get blendMode(): string {
+    switch (this.alphaFilter.blendMode) {
+      case PIXI.BLEND_MODES.NORMAL:
+        return 'normal';
+      case PIXI.BLEND_MODES.ADD:
+        return 'add';
+      case PIXI.BLEND_MODES.MULTIPLY:
+        return 'multiply';
+      case PIXI.BLEND_MODES.SCREEN:
+        return 'screen';
+      default:
+        logger.warn(`Unknown blend mode: ${this.alphaFilter.blendMode}, returning normal.`);
+        return 'normal';
+    }
+  }
+  public set blendMode(v: string) {
+    switch (v) {
+      case 'normal':
+        this.alphaFilter.blendMode = PIXI.BLEND_MODES.NORMAL;
+        break;
+      case 'add':
+        this.alphaFilter.blendMode = PIXI.BLEND_MODES.ADD;
+        break;
+      case 'multiply':
+        this.alphaFilter.blendMode = PIXI.BLEND_MODES.MULTIPLY;
+        break;
+      case 'screen':
+        this.alphaFilter.blendMode = PIXI.BLEND_MODES.SCREEN;
+        break;
+      default:
+        logger.warn(`Unknown blend mode: ${v}, setting to normal.`);
+        this.alphaFilter.blendMode = PIXI.BLEND_MODES.NORMAL;
+    }
+  }
   public removeFilterByName(filterName: string) {
     const filter = this.containerFilters.get(filterName);
     if (!filter || !this.filters) return;

--- a/packages/webgal/src/Core/gameScripts/changeFigure.ts
+++ b/packages/webgal/src/Core/gameScripts/changeFigure.ts
@@ -91,6 +91,7 @@ export function changeFigure(sentence: ISentence): IPerform {
   const enterAnimation = getStringArgByKey(sentence, 'enter');
   const exitAnimation = getStringArgByKey(sentence, 'exit');
   let zIndex = getNumberArgByKey(sentence, 'zIndex') ?? -1;
+  let blendMode = getStringArgByKey(sentence, 'blendMode');
   const enterDuration = getNumberArgByKey(sentence, 'enterDuration') ?? duration;
   duration = enterDuration;
   const exitDuration = getNumberArgByKey(sentence, 'exitDuration') ?? DEFAULT_FIG_OUT_DURATION;
@@ -232,11 +233,13 @@ export function changeFigure(sentence: ISentence): IPerform {
       blink = blink ?? cloneDeep(baseBlinkParam);
       focus = focus ?? cloneDeep(baseFocusParam);
       zIndex = Math.max(zIndex, 0);
+      blendMode = blendMode ?? 'normal';
       dispatch(stageActions.setLive2dMotion({ target: key, motion, overrideBounds: bounds }));
       dispatch(stageActions.setLive2dExpression({ target: key, expression }));
       dispatch(stageActions.setLive2dBlink({ target: key, blink }));
       dispatch(stageActions.setLive2dFocus({ target: key, focus }));
       dispatch(stageActions.setFigureMetaData([key, 'zIndex', zIndex, false]));
+      dispatch(stageActions.setFigureMetaData([key, 'blendMode', blendMode, false]));
     } else {
       // 当 url 没有发生变化时，即没有新立绘替换
       // 应当保留旧立绘的状态，仅在需要时更新
@@ -254,6 +257,9 @@ export function changeFigure(sentence: ISentence): IPerform {
       }
       if (zIndex >= 0) {
         dispatch(stageActions.setFigureMetaData([key, 'zIndex', zIndex, false]));
+      }
+      if (blendMode) {
+        dispatch(stageActions.setFigureMetaData([key, 'blendMode', blendMode, false]));
       }
     }
   }

--- a/packages/webgal/src/Stage/MainStage/useSetFigure.ts
+++ b/packages/webgal/src/Stage/MainStage/useSetFigure.ts
@@ -63,8 +63,13 @@ export function useSetFigure(stageState: IStageState) {
   useEffect(() => {
     Object.entries(figureMetaData).forEach(([key, value]) => {
       const figureObject = WebGAL.gameplay.pixiStage?.getStageObjByKey(key);
-      if (figureObject && !figureObject.isExiting && value?.zIndex !== undefined && figureObject.pixiContainer) {
-        figureObject.pixiContainer.zIndex = value.zIndex;
+      if (figureObject && !figureObject.isExiting && figureObject.pixiContainer) {
+        if (value.zIndex !== undefined) {
+          figureObject.pixiContainer.zIndex = value.zIndex;
+        }
+        if (value.blendMode !== undefined) {
+          figureObject.pixiContainer.blendMode = value.blendMode;
+        }
       }
     });
   }, [figureMetaData]);

--- a/packages/webgal/src/store/stageInterface.ts
+++ b/packages/webgal/src/store/stageInterface.ts
@@ -185,6 +185,7 @@ export interface ILive2DFocus {
 
 export interface IFigureMetadata {
   zIndex?: number;
+  blendMode?: string;
 }
 
 type figureMetaData = Record<string, IFigureMetadata>;


### PR DESCRIPTION
# 介绍

为立绘添加 __混合模式__ 参数, 可用的值有:

- normal 正常(默认值)
- add 线性减淡
- multiply 正片叠底
- screen 滤色

<img width="1737" height="661" alt="image" src="https://github.com/user-attachments/assets/675c1e20-33d0-47f1-87e6-fa05caaa40ae" />


# 测试

### 简单测试

``` bash
changeBg:bg.webp -transform={"brightness":0.5};
changeFigure:stand.webp -id=aaa;
changeFigure:stand.webp -id=aaa -blendMode=add;
changeFigure:stand.webp -id=aaa -blendMode=multiply;
changeFigure:stand.webp -id=aaa -blendMode=screen;
changeFigure:stand.webp -id=aaa -blendMode=normal;
```

### 稍好看一点的测试

请将下面两张图片放到 `/game/figure/shapes` 下

<table>
<tr>
<td>linear_transparent.webp</td>
<td>radial_transparent.webp</td>
</tr>
<tr>
<td>
<img src=https://github.com/user-attachments/assets/55e2c2bd-aa67-4d04-b401-bbc679194783 />
</td>
<td>
<img src=https://github.com/user-attachments/assets/449ca8a9-ce9c-4896-914f-92d2360875e5 />
</td>
</tr>
</table>

``` bash
changeBg:bg.webp -transform={"brightness":0.829,"gamma":0.634};
changeFigure:stand.png -id=aaa -transform={"position":{"y":160},"scale":{"x":1.5,"y":1.5},"brightness":0.89,"contrast":1.037,"gamma":0.646,"bevelRed":255,"bevelGreen":255,"bevelBlue":255} -zIndex=3;
; 背景暖光
changeFigure:shapes/radial_transparent.webp -id=bg_warm_light -transform={"position":{"x":-390,"y":-549},"scale":{"x":2,"y":2},"alpha":0.762,"brightness":0.683,"colorRed":255,"colorGreen":214,"colorBlue":148} -zIndex=0 -blendMode=add;
; 背景冷光
changeFigure:shapes/linear_transparent.webp -id=bg_cold_light -transform={"position":{"x":793,"y":598},"scale":{"x":2.5,"y":1.756},"rotation":2.528,"alpha":1,"brightness":2,"colorRed":120,"colorGreen":69,"colorBlue":255} -zIndex=1 -blendMode=multiply;
; 脸部亮光
changeFigure:shapes/radial_transparent.webp -id=face_light -transform={"position":{"x":-110,"y":-183},"scale":{"x":0.963,"y":1.098},"alpha":0.128,"brightness":1.841,"colorRed":255,"colorGreen":111,"colorBlue":51} -zIndex=4 -blendMode=screen;
```
