### PR TITLE
fix: ensure live2d blink focus in state is full

### DIFF
--- a/packages/webgal/src/store/stageReducer.ts
+++ b/packages/webgal/src/store/stageReducer.ts
@@ -23,6 +23,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import cloneDeep from 'lodash/cloneDeep';
 import { commandType } from '@/Core/controller/scene/sceneInterface';
 import { STAGE_KEYS } from '@/Core/constants';
+import { baseBlinkParam, baseFocusParam } from '@/Core/live2DCore';
 
 // 初始化舞台数据
 
@@ -275,10 +276,12 @@ const stageSlice = createSlice({
       const index = state.live2dBlink.findIndex((e) => e.target === target);
       if (index < 0) {
         // Add a new blink
-        state.live2dBlink.push({ target, blink });
+        const fullBlink = { ...baseBlinkParam, ...blink };
+        state.live2dBlink.push({ target, blink: fullBlink });
       } else {
         // Update the existing blink
-        state.live2dBlink[index].blink = blink;
+        const fullBlink = { ...state.live2dBlink[index].blink, ...blink };
+        state.live2dBlink[index].blink = fullBlink;
       }
     },
     setLive2dFocus: (state, action: PayloadAction<ILive2DFocus>) => {
@@ -287,10 +290,12 @@ const stageSlice = createSlice({
       const index = state.live2dFocus.findIndex((e) => e.target === target);
       if (index < 0) {
         // Add a new focus
-        state.live2dFocus.push({ target, focus });
+        const fullFocus = { ...baseFocusParam, ...focus };
+        state.live2dFocus.push({ target, focus: fullFocus });
       } else {
         // Update the existing focus
-        state.live2dFocus[index].focus = focus;
+        const fullFocus = { ...state.live2dFocus[index].focus, ...focus };
+        state.live2dFocus[index].focus = fullFocus;
       }
     },
     replaceUIlable: (state, action: PayloadAction<[string, string]>) => {


### PR DESCRIPTION
# 介绍

修复 stage state 中 live2dBlink 和 live2dFocus 参数可能不完整的问题

# 测试

``` bash
changeFigure: path/to/model.json -id=aaa -focus={"x":-1} -next;
:focus left;
changeFigure: path/to/model.json -id=aaa -focus={"y":1} -next;
:focus left up (继承上一句的 left);
```

此 PR 前, 播放到最后一句, 再读档读到第一句, 并不会真的 focus left, 因为那时 focus 参数在 state 中不完整