### PR TITLE
fix: timeline animation error

### DIFF
--- a/packages/webgal/src/Core/controller/stage/pixi/animations/timeline.ts
+++ b/packages/webgal/src/Core/controller/stage/pixi/animations/timeline.ts
@@ -41,8 +41,8 @@ export function generateTimelineObj(
   }
   const container = target?.pixiContainer;
   let animateInstance: ReturnType<typeof popmotion.animate> | null = null;
-  // 只有有 duration 的时候才有动画
-  if (duration > 0) {
+  // 只有有 duration 且 timeline 长度大于 1 的时候才有动画
+  if (duration > 0 && timeline.length > 1) {
     animateInstance = popmotion.animate({
       to: values,
       offset: times,


### PR DESCRIPTION
# 介绍

修复 timeline 动画仅有一段, 但 duration 不为 0 时, 此后所有动画都失效的问题

fix #808 

# 测试

``` bash
changeBg:bg.webp;
changeFigure:stand.webp -id=aaa;
; 执行下面这一句后, 所有动画失效
setTempAnimation:[{"duration":1000,"position":{"x":-300}}] -target=aaa;
setTransform:{"position":{"x":300}} -duration=1000 -target=aaa;
```