### PR TITLE
fix: keep animation error

### DIFF
--- a/packages/webgal/src/Core/gameScripts/setAnimation.ts
+++ b/packages/webgal/src/Core/gameScripts/setAnimation.ts
@@ -13,7 +13,6 @@ import { WebGAL } from '@/Core/WebGAL';
  * @param sentence
  */
 export const setAnimation = (sentence: ISentence): IPerform => {
-  const startDialogKey = webgalStore.getState().stage.currentDialogKey;
   const animationName = sentence.content;
   const animationDuration = getAnimateDuration(animationName);
   let target = getStringArgByKey(sentence, 'target') ?? '';
@@ -23,11 +22,15 @@ export const setAnimation = (sentence: ISentence): IPerform => {
 
   const key = `${target}-${animationName}-${animationDuration}`;
   const performInitName = `animation-${target}`;
+  let keepAnimationStopped = false;
 
   WebGAL.gameplay.performController.unmountPerform(performInitName, true);
 
   let stopFunction;
   setTimeout(() => {
+    if (keep && keepAnimationStopped) {
+      return;
+    }
     WebGAL.gameplay.pixiStage?.stopPresetAnimationOnTarget(target);
     const animationObj: IAnimationObject | null = getAnimationObject(
       animationName,
@@ -41,9 +44,12 @@ export const setAnimation = (sentence: ISentence): IPerform => {
     }
   }, 0);
   stopFunction = () => {
+    if (keep) {
+      WebGAL.gameplay.pixiStage?.removeAnimationWithoutSetEndState(key);
+      keepAnimationStopped = true;
+      return;
+    }
     setTimeout(() => {
-      const endDialogKey = webgalStore.getState().stage.currentDialogKey;
-      const isHasNext = startDialogKey !== endDialogKey;
       WebGAL.gameplay.pixiStage?.removeAnimationWithSetEffects(key);
     }, 0);
   };

--- a/packages/webgal/src/Core/gameScripts/setTempAnimation.ts
+++ b/packages/webgal/src/Core/gameScripts/setTempAnimation.ts
@@ -16,7 +16,6 @@ import { WebGAL } from '@/Core/WebGAL';
  * @param sentence
  */
 export const setTempAnimation = (sentence: ISentence): IPerform => {
-  const startDialogKey = webgalStore.getState().stage.currentDialogKey;
   const animationName = (Math.random() * 10).toString(16);
   const animationString = sentence.content;
   let animationObj;
@@ -34,11 +33,15 @@ export const setTempAnimation = (sentence: ISentence): IPerform => {
 
   const key = `${target}-${animationName}-${animationDuration}`;
   const performInitName = `animation-${target}`;
+  let keepAnimationStopped = false;
 
   WebGAL.gameplay.performController.unmountPerform(performInitName, true);
 
   let stopFunction = () => {};
   setTimeout(() => {
+    if (keep && keepAnimationStopped) {
+      return;
+    }
     WebGAL.gameplay.pixiStage?.stopPresetAnimationOnTarget(target);
     const animationObj: IAnimationObject | null = getAnimationObject(
       animationName,
@@ -52,9 +55,12 @@ export const setTempAnimation = (sentence: ISentence): IPerform => {
     }
   }, 0);
   stopFunction = () => {
+    if (keep) {
+      WebGAL.gameplay.pixiStage?.removeAnimationWithoutSetEndState(key);
+      keepAnimationStopped = true;
+      return;
+    }
     setTimeout(() => {
-      const endDialogKey = webgalStore.getState().stage.currentDialogKey;
-      const isHasNext = startDialogKey !== endDialogKey;
       WebGAL.gameplay.pixiStage?.removeAnimationWithSetEffects(key);
     }, 0);
   };

--- a/packages/webgal/src/Core/gameScripts/setTransform.ts
+++ b/packages/webgal/src/Core/gameScripts/setTransform.ts
@@ -17,7 +17,6 @@ import { getAnimateDuration, getAnimationObject } from '../Modules/animationFunc
  * @param sentence
  */
 export const setTransform = (sentence: ISentence): IPerform => {
-  const startDialogKey = webgalStore.getState().stage.currentDialogKey;
   const animationName = (Math.random() * 10).toString(16);
   const animationString = sentence.content;
   let animationObj: AnimationFrame[];


### PR DESCRIPTION
# 介绍

修复 `setTempAnimation` 和 `setAnimation` 还在播 keep 动画时, 目标对象提前退场, 导致的后续所有动画失效的问题

本质上是 #775 方案的延续, 但是那个 PR 只处理了 `setTransform`

# 测试

下面这段代码多试几次, 多滚滚轮, 此 PR 前有概率造成所有动画失效

``` bash
label:loop;
;
changeFigure:stand.webp -id=aaa -next;
:出场;
setTempAnimation:[{"duration":0}, {"scale":{"x":5, "y":5}, "duration":10000}] -target=aaa -keep -next;
:keep;
changeFigure:none -id=aaa -next;
:退场;
;
jumpLabel:loop;
```