### PR TITLE
feat: extend transform argument usage

### DIFF
--- a/packages/webgal/src/Core/Modules/animationFunctions.ts
+++ b/packages/webgal/src/Core/Modules/animationFunctions.ts
@@ -118,25 +118,18 @@ export function registerTimelineAnimation(
   target: string,
   animationDuration: number,
   writeDefault: boolean,
-  keep: boolean,
-  keepAnimationStopped: boolean,
 ) {
-  setTimeout(() => {
-    if (keep && keepAnimationStopped) {
-      return;
-    }
-    WebGAL.gameplay.pixiStage?.stopPresetAnimationOnTarget(target);
-    const animationObj: IAnimationObject | null = getAnimationObject(
-      animationName,
-      target,
-      animationDuration,
-      writeDefault,
-    );
-    if (animationObj) {
-      logger.debug(`动画${animationName}作用在${target}`, animationDuration);
-      WebGAL.gameplay.pixiStage?.registerAnimation(animationObj, animationKey, target);
-    }
-  }, 0);
+  WebGAL.gameplay.pixiStage?.stopPresetAnimationOnTarget(target);
+  const animationObj: IAnimationObject | null = getAnimationObject(
+    animationName,
+    target,
+    animationDuration,
+    writeDefault,
+  );
+  if (animationObj) {
+    logger.debug(`动画${animationName}作用在${target}`, animationDuration);
+    WebGAL.gameplay.pixiStage?.registerAnimation(animationObj, animationKey, target);
+  }
 }
 
 export function removeTimelineAnimation(animationKey: string, keep: boolean): boolean {

--- a/packages/webgal/src/Core/Modules/animationFunctions.ts
+++ b/packages/webgal/src/Core/Modules/animationFunctions.ts
@@ -110,3 +110,42 @@ export function getEnterExitAnimation(
     return { duration, animation };
   }
 }
+
+// eslint-disable-next-line max-params
+export function registerTimelineAnimation(
+  animationName: string,
+  animationKey: string,
+  target: string,
+  animationDuration: number,
+  writeDefault: boolean,
+  keep: boolean,
+  keepAnimationStopped: boolean,
+) {
+  setTimeout(() => {
+    if (keep && keepAnimationStopped) {
+      return;
+    }
+    WebGAL.gameplay.pixiStage?.stopPresetAnimationOnTarget(target);
+    const animationObj: IAnimationObject | null = getAnimationObject(
+      animationName,
+      target,
+      animationDuration,
+      writeDefault,
+    );
+    if (animationObj) {
+      logger.debug(`动画${animationName}作用在${target}`, animationDuration);
+      WebGAL.gameplay.pixiStage?.registerAnimation(animationObj, animationKey, target);
+    }
+  }, 0);
+}
+
+export function removeTimelineAnimation(animationKey: string, keep: boolean): boolean {
+  if (keep) {
+    WebGAL.gameplay.pixiStage?.removeAnimationWithoutSetEndState(animationKey);
+    return true;
+  }
+  setTimeout(() => {
+    WebGAL.gameplay.pixiStage?.removeAnimationWithSetEffects(animationKey);
+  }, 0);
+  return false;
+}

--- a/packages/webgal/src/Core/gameScripts/changeBg/index.ts
+++ b/packages/webgal/src/Core/gameScripts/changeBg/index.ts
@@ -74,6 +74,8 @@ export const changeBg = (sentence: ISentence): IPerform => {
           stageActions.updateAnimationSettings({ target: 'bg-main', key: 'enterAnimationName', value: animationName }),
         );
       } else {
+        const animationPerformInitName = `animation-bg-main`;
+        WebGAL.gameplay.performController.unmountPerform(animationPerformInitName, true);
         setTimeout(() => {
           registerTimelineAnimation(animationName, animationKey, 'bg-main', duration, writeDefault);
         }, 0);
@@ -97,7 +99,9 @@ export const changeBg = (sentence: ISentence): IPerform => {
       webgalStore.dispatch(
         stageActions.updateAnimationSettings({ target: 'bg-main', key: 'enterAnimationName', value: animationName }),
       );
-    } else {
+    } else if (transformString) {
+      const animationPerformInitName = `animation-bg-main`;
+      WebGAL.gameplay.performController.unmountPerform(animationPerformInitName, true);
       setTimeout(() => {
         registerTimelineAnimation(animationName, animationKey, 'bg-main', duration, writeDefault);
       }, 0);

--- a/packages/webgal/src/Core/gameScripts/changeBg/index.ts
+++ b/packages/webgal/src/Core/gameScripts/changeBg/index.ts
@@ -74,7 +74,9 @@ export const changeBg = (sentence: ISentence): IPerform => {
           stageActions.updateAnimationSettings({ target: 'bg-main', key: 'enterAnimationName', value: animationName }),
         );
       } else {
-        registerTimelineAnimation(animationName, animationKey, 'bg-main', duration, writeDefault, false, false);
+        setTimeout(() => {
+          registerTimelineAnimation(animationName, animationKey, 'bg-main', duration, writeDefault);
+        }, 0);
       }
     } catch (e) {
       // 解析都错误了，歇逼吧
@@ -96,7 +98,9 @@ export const changeBg = (sentence: ISentence): IPerform => {
         stageActions.updateAnimationSettings({ target: 'bg-main', key: 'enterAnimationName', value: animationName }),
       );
     } else {
-      registerTimelineAnimation(animationName, animationKey, 'bg-main', duration, writeDefault, false, false);
+      setTimeout(() => {
+        registerTimelineAnimation(animationName, animationKey, 'bg-main', duration, writeDefault);
+      }, 0);
     }
   }
 

--- a/packages/webgal/src/Core/gameScripts/changeFigure.ts
+++ b/packages/webgal/src/Core/gameScripts/changeFigure.ts
@@ -184,6 +184,8 @@ export function changeFigure(sentence: ISentence): IPerform {
             stageActions.updateAnimationSettings({ target: key, key: 'enterAnimationName', value: animationName }),
           );
         } else {
+          const animationPerformInitName = `animation-${id}`;
+          WebGAL.gameplay.performController.unmountPerform(animationPerformInitName, true);
           setTimeout(() => {
             registerTimelineAnimation(animationName, animationKey, id, duration, writeDefault);
           }, 0);
@@ -207,7 +209,9 @@ export function changeFigure(sentence: ISentence): IPerform {
         webgalStore.dispatch(
           stageActions.updateAnimationSettings({ target: key, key: 'enterAnimationName', value: animationName }),
         );
-      } else {
+      } else if (transformString) {
+        const animationPerformInitName = `animation-${id}`;
+        WebGAL.gameplay.performController.unmountPerform(animationPerformInitName, true);
         setTimeout(() => {
           registerTimelineAnimation(animationName, animationKey, id, duration, writeDefault);
         }, 0);

--- a/packages/webgal/src/Core/gameScripts/changeFigure.ts
+++ b/packages/webgal/src/Core/gameScripts/changeFigure.ts
@@ -184,7 +184,9 @@ export function changeFigure(sentence: ISentence): IPerform {
             stageActions.updateAnimationSettings({ target: key, key: 'enterAnimationName', value: animationName }),
           );
         } else {
-          registerTimelineAnimation(animationName, animationKey, id, duration, writeDefault, false, false);
+          setTimeout(() => {
+            registerTimelineAnimation(animationName, animationKey, id, duration, writeDefault);
+          }, 0);
         }
       } catch (e) {
         // 解析都错误了，歇逼吧
@@ -206,7 +208,9 @@ export function changeFigure(sentence: ISentence): IPerform {
           stageActions.updateAnimationSettings({ target: key, key: 'enterAnimationName', value: animationName }),
         );
       } else {
-        registerTimelineAnimation(animationName, animationKey, id, duration, writeDefault, false, false);
+        setTimeout(() => {
+          registerTimelineAnimation(animationName, animationKey, id, duration, writeDefault);
+        }, 0);
       }
     }
 

--- a/packages/webgal/src/Core/gameScripts/setAnimation.ts
+++ b/packages/webgal/src/Core/gameScripts/setAnimation.ts
@@ -29,15 +29,12 @@ export const setAnimation = (sentence: ISentence): IPerform => {
   const animationKey = `${target}-${animationName}-${animationDuration}`;
   let keepAnimationStopped = false;
 
-  registerTimelineAnimation(
-    animationName,
-    animationKey,
-    target,
-    animationDuration,
-    writeDefault,
-    keep,
-    keepAnimationStopped,
-  );
+  setTimeout(() => {
+    if (keep && keepAnimationStopped) {
+      return;
+    }
+    registerTimelineAnimation(animationName, animationKey, target, animationDuration, writeDefault);
+  }, 0);
 
   const stopFunction = () => {
     keepAnimationStopped = removeTimelineAnimation(animationKey, keep);

--- a/packages/webgal/src/Core/gameScripts/setAnimation.ts
+++ b/packages/webgal/src/Core/gameScripts/setAnimation.ts
@@ -1,11 +1,14 @@
 import { ISentence } from '@/Core/controller/scene/sceneInterface';
 import { IPerform } from '@/Core/Modules/perform/performInterface';
 import { getBooleanArgByKey, getStringArgByKey } from '@/Core/util/getSentenceArg';
-import { IAnimationObject } from '@/Core/controller/stage/pixi/PixiController';
 import { logger } from '@/Core/util/logger';
 import { webgalStore } from '@/store/store';
 
-import { getAnimateDuration, getAnimationObject } from '@/Core/Modules/animationFunctions';
+import {
+  getAnimateDuration,
+  registerTimelineAnimation,
+  removeTimelineAnimation,
+} from '@/Core/Modules/animationFunctions';
 import { WebGAL } from '@/Core/WebGAL';
 
 /**
@@ -13,7 +16,6 @@ import { WebGAL } from '@/Core/WebGAL';
  * @param sentence
  */
 export const setAnimation = (sentence: ISentence): IPerform => {
-  const startDialogKey = webgalStore.getState().stage.currentDialogKey;
   const animationName = sentence.content;
   const animationDuration = getAnimateDuration(animationName);
   let target = getStringArgByKey(sentence, 'target') ?? '';
@@ -21,31 +23,24 @@ export const setAnimation = (sentence: ISentence): IPerform => {
   const writeDefault = getBooleanArgByKey(sentence, 'writeDefault') ?? false;
   const keep = getBooleanArgByKey(sentence, 'keep') ?? false;
 
-  const key = `${target}-${animationName}-${animationDuration}`;
   const performInitName = `animation-${target}`;
-
   WebGAL.gameplay.performController.unmountPerform(performInitName, true);
 
-  let stopFunction;
-  setTimeout(() => {
-    WebGAL.gameplay.pixiStage?.stopPresetAnimationOnTarget(target);
-    const animationObj: IAnimationObject | null = getAnimationObject(
-      animationName,
-      target,
-      animationDuration,
-      writeDefault,
-    );
-    if (animationObj) {
-      logger.debug(`动画${animationName}作用在${target}`, animationDuration);
-      WebGAL.gameplay.pixiStage?.registerAnimation(animationObj, key, target);
-    }
-  }, 0);
-  stopFunction = () => {
-    setTimeout(() => {
-      const endDialogKey = webgalStore.getState().stage.currentDialogKey;
-      const isHasNext = startDialogKey !== endDialogKey;
-      WebGAL.gameplay.pixiStage?.removeAnimationWithSetEffects(key);
-    }, 0);
+  const animationKey = `${target}-${animationName}-${animationDuration}`;
+  let keepAnimationStopped = false;
+
+  registerTimelineAnimation(
+    animationName,
+    animationKey,
+    target,
+    animationDuration,
+    writeDefault,
+    keep,
+    keepAnimationStopped,
+  );
+
+  const stopFunction = () => {
+    keepAnimationStopped = removeTimelineAnimation(animationKey, keep);
   };
 
   return {

--- a/packages/webgal/src/Core/gameScripts/setTempAnimation.ts
+++ b/packages/webgal/src/Core/gameScripts/setTempAnimation.ts
@@ -40,15 +40,12 @@ export const setTempAnimation = (sentence: ISentence): IPerform => {
   const animationKey = `${target}-${animationName}-${animationDuration}`;
   let keepAnimationStopped = false;
 
-  registerTimelineAnimation(
-    animationName,
-    animationKey,
-    target,
-    animationDuration,
-    writeDefault,
-    keep,
-    keepAnimationStopped,
-  );
+  setTimeout(() => {
+    if (keep && keepAnimationStopped) {
+      return;
+    }
+    registerTimelineAnimation(animationName, animationKey, target, animationDuration, writeDefault);
+  }, 0);
 
   const stopFunction = () => {
     keepAnimationStopped = removeTimelineAnimation(animationKey, keep);

--- a/packages/webgal/src/Core/gameScripts/setTransform.ts
+++ b/packages/webgal/src/Core/gameScripts/setTransform.ts
@@ -10,14 +10,13 @@ import { baseTransform, ITransform } from '@/store/stageInterface';
 import { AnimationFrame, IUserAnimation } from '../Modules/animations';
 import { generateTransformAnimationObj } from '@/Core/controller/stage/pixi/animations/generateTransformAnimationObj';
 import { WebGAL } from '@/Core/WebGAL';
-import { getAnimateDuration, getAnimationObject } from '../Modules/animationFunctions';
+import { getAnimateDuration, registerTimelineAnimation, removeTimelineAnimation } from '../Modules/animationFunctions';
 
 /**
  * 设置变换
  * @param sentence
  */
 export const setTransform = (sentence: ISentence): IPerform => {
-  const startDialogKey = webgalStore.getState().stage.currentDialogKey;
   const animationName = (Math.random() * 10).toString(16);
   const animationString = sentence.content;
   let animationObj: AnimationFrame[];
@@ -29,7 +28,6 @@ export const setTransform = (sentence: ISentence): IPerform => {
   const keep = getBooleanArgByKey(sentence, 'keep') ?? false;
 
   const performInitName = `animation-${target}`;
-
   WebGAL.gameplay.performController.unmountPerform(performInitName, true);
 
   try {
@@ -45,33 +43,21 @@ export const setTransform = (sentence: ISentence): IPerform => {
   WebGAL.animationManager.addAnimation(newAnimation);
   const animationDuration = getAnimateDuration(animationName);
 
-  const key = `${target}-${animationName}-${animationDuration}`;
+  const animationKey = `${target}-${animationName}-${animationDuration}`;
   let keepAnimationStopped = false;
-  setTimeout(() => {
-    if (keep && keepAnimationStopped) {
-      return;
-    }
-    WebGAL.gameplay.pixiStage?.stopPresetAnimationOnTarget(target);
-    const animationObj: IAnimationObject | null = getAnimationObject(
-      animationName,
-      target,
-      animationDuration,
-      writeDefault,
-    );
-    if (animationObj) {
-      logger.debug(`动画${animationName}作用在${target}`, animationDuration);
-      WebGAL.gameplay.pixiStage?.registerAnimation(animationObj, key, target);
-    }
-  }, 0);
+
+  registerTimelineAnimation(
+    animationName,
+    animationKey,
+    target,
+    animationDuration,
+    writeDefault,
+    keep,
+    keepAnimationStopped,
+  );
+
   const stopFunction = () => {
-    if (keep) {
-      WebGAL.gameplay.pixiStage?.removeAnimationWithoutSetEndState(key);
-      keepAnimationStopped = true;
-      return;
-    }
-    setTimeout(() => {
-      WebGAL.gameplay.pixiStage?.removeAnimationWithSetEffects(key);
-    }, 0);
+    keepAnimationStopped = removeTimelineAnimation(animationKey, keep);
   };
 
   return {

--- a/packages/webgal/src/Core/gameScripts/setTransform.ts
+++ b/packages/webgal/src/Core/gameScripts/setTransform.ts
@@ -46,15 +46,12 @@ export const setTransform = (sentence: ISentence): IPerform => {
   const animationKey = `${target}-${animationName}-${animationDuration}`;
   let keepAnimationStopped = false;
 
-  registerTimelineAnimation(
-    animationName,
-    animationKey,
-    target,
-    animationDuration,
-    writeDefault,
-    keep,
-    keepAnimationStopped,
-  );
+  setTimeout(() => {
+    if (keep && keepAnimationStopped) {
+      return;
+    }
+    registerTimelineAnimation(animationName, animationKey, target, animationDuration, writeDefault);
+  }, 0);
 
   const stopFunction = () => {
     keepAnimationStopped = removeTimelineAnimation(animationKey, keep);


### PR DESCRIPTION
# 介绍

在 `changeBg` `changeFigure` url 未更改时, `-transform` 参数会像 `setTransform` 命令一样工作

相当于以前的

``` bash
changFigure: stand.webp -id=aaa -transform={"position":{"x":-500}};
setTransform: {"position":{"x":500}} -target=aaa -duration=1500;
```

现在可以写成

``` bash
changFigure: stand.webp -id=aaa -transform={"position":{"x":-500}};
changFigure: stand.webp -id=aaa -transform={"position":{"x":500}} -duration=1500;
```

这对于一边更改立绘/背景参数 (如 zIndex, live2d 的 motion expression), 一边做变换效果的情况, 可以简写为一行, 同时也减少了很多新手问 __为什么我设置(changeFigure)的变换效果没有动画__ 的情况

因为有 `isUrlChanged` 做隔离, 所以按理说应该不会影响入场退场的逻辑

为 `changeBg` `changeFigure` 添加了 `writeDefault` 参数, 但是 `keep` 暂时不加, 我总感觉有点隐式的问题, 等我以后相通了再加

这个 PR 实际上与 #863 有一点点重叠, 不过问题不大

编辑器那边等这个 PR 合并后, 再移除掉那个"请用设置效果命令" 的提示