### PR TITLE
fix: 修复 IMSS 文本框中 emoji 无法正常显示的问题

### DIFF
--- a/packages/webgal/src/Stage/TextBox/IMSSTextbox.tsx
+++ b/packages/webgal/src/Stage/TextBox/IMSSTextbox.tsx
@@ -1,5 +1,5 @@
 import styles from './textbox.module.scss';
-import { useEffect } from 'react';
+import { isValidElement, ReactNode, useEffect } from 'react';
 import { WebGAL } from '@/Core/WebGAL';
 import { ITextboxProps } from './types';
 import useApplyStyle from '@/hooks/useApplyStyle';
@@ -7,6 +7,26 @@ import { css } from '@emotion/css';
 import { textSize } from '@/store/userDataInterface';
 import { useSelector } from 'react-redux';
 import { RootState } from '@/store/store';
+
+const EMOJI_REGEX = /\p{Extended_Pictographic}|\p{Emoji_Presentation}/u;
+
+function getNodeTextContent(node: ReactNode): string {
+  if (typeof node === 'string' || typeof node === 'number') {
+    return String(node);
+  }
+  if (Array.isArray(node)) {
+    return node.map((item) => getNodeTextContent(item)).join('');
+  }
+  if (isValidElement(node)) {
+    return getNodeTextContent(node.props.children);
+  }
+  return '';
+}
+
+function shouldRenderPlainText(node: ReactNode): boolean {
+  const text = getNodeTextContent(node);
+  return EMOJI_REGEX.test(text);
+}
 
 export default function IMSSTextbox(props: ITextboxProps) {
   const {
@@ -72,6 +92,13 @@ export default function IMSSTextbox(props: ITextboxProps) {
       }
       const styleClassName = ' ' + css(style, { label: 'showname' });
       const styleAllText = ' ' + css(style_alltext, { label: 'showname' });
+      if (shouldRenderPlainText(e)) {
+        return (
+          <span key={index} style={{ position: 'relative' }} className={styleClassName + styleAllText}>
+            {e}
+          </span>
+        );
+      }
       if (isEnhanced) {
         return (
           <span key={index} style={{ position: 'relative' }}>
@@ -140,6 +167,8 @@ export default function IMSSTextbox(props: ITextboxProps) {
       }
       const styleClassName = ' ' + css(style);
       const styleAllText = ' ' + css(style_alltext);
+      const isPlainText = shouldRenderPlainText(e);
+
       if (allTextIndex < prevLength) {
         return (
           <span
@@ -149,11 +178,15 @@ export default function IMSSTextbox(props: ITextboxProps) {
             key={currentDialogKey + index}
             style={{ animationDelay: `${delay}ms`, animationDuration: `${textDuration}ms` }}
           >
-            <span className={styles.zhanwei + styleAllText}>
-              {e}
-              <span className={applyStyle('outer', styles.outer) + styleClassName + styleAllText}>{e}</span>
-              {isUseStroke && <span className={applyStyle('inner', styles.inner) + styleAllText}>{e}</span>}
-            </span>
+        {isPlainText ? (
+              <span className={styleClassName + styleAllText}>{e}</span>
+            ) : (
+              <span className={styles.zhanwei + styleAllText}>
+                {e}
+                <span className={applyStyle('outer', styles.outer) + styleClassName + styleAllText}>{e}</span>
+                {isUseStroke && <span className={applyStyle('inner', styles.inner) + styleAllText}>{e}</span>}
+              </span>
+            )}
           </span>
         );
       }
@@ -165,11 +198,15 @@ export default function IMSSTextbox(props: ITextboxProps) {
           key={currentDialogKey + index}
           style={{ animationDelay: `${delay}ms`, position: 'relative' }}
         >
-          <span className={styles.zhanwei + styleAllText}>
-            {e}
-            <span className={applyStyle('outer', styles.outer) + styleClassName + styleAllText}>{e}</span>
-            {isUseStroke && <span className={applyStyle('inner', styles.inner) + styleAllText}>{e}</span>}
-          </span>
+        {isPlainText ? (
+            <span className={styleClassName + styleAllText}>{e}</span>
+          ) : (
+            <span className={styles.zhanwei + styleAllText}>
+              {e}
+              <span className={applyStyle('outer', styles.outer) + styleClassName + styleAllText}>{e}</span>
+              {isUseStroke && <span className={applyStyle('inner', styles.inner) + styleAllText}>{e}</span>}
+            </span>
+          )}
         </span>
       );
     });


### PR DESCRIPTION
# 修复 IMSS 文本框中 emoji 无法正常显示的问题。
此前文本框会将所有文本统一渲染为多层叠加结构（`outer` / `inner` / `zhanwei`），通过透明文字、渐变和描边来实现视觉效果。这套方案对普通文字有效，但会破坏彩色 emoji 的正常渲染。我之前即使将`Segoe UI Emoji`或者`Noto Emoji`等设为回退字体也依然会持出现emoji只有轮廓但是被涂黑的情况

本次修改增加了对 emoji 内容的检测：
当检测到当前节点包含 emoji 时，不再走渐变描边的叠层渲染，而是改为普通文本渲染，从而让系统 emoji 字体回退机制正常生效。

## 问题原因

问题不在于字体没有注册，而在于文本框当前的特效实现方式会影响彩色 emoji 的显示。
`"Segoe UI Emoji"` 作为系统字体本身可以直接作为回退字体使用，但由于文本实际是通过透明占位和多层覆盖来呈现的，导致 emoji 无法按正常方式绘制。

## 修改内容

- 在 `IMSSTextbox` 中增加 emoji 检测逻辑

## 验证方式

- 在对话脚本中插入 emoji，确认 IMSS 文本框可以正常显示
- 通过类型检查：