### PR TITLE
fix: supplement transform interface

### DIFF
--- a/packages/webgal/src/store/stageInterface.ts
+++ b/packages/webgal/src/store/stageInterface.ts
@@ -58,6 +58,12 @@ export interface ITransform {
   bloomBrightness: number;
   bloomBlur: number;
   bloomThreshold: number;
+  oldFilm: number;
+  dotFilm: number;
+  reflectionFilm: number;
+  glitchFilm: number;
+  rgbFilm: number;
+  godrayFilm: number;
   shockwaveFilter: number;
   radiusAlphaFilter: number;
 }
@@ -124,6 +130,12 @@ export const baseTransform: ITransform = {
   bloomBrightness: 1,
   bloomBlur: 0,
   bloomThreshold: 0,
+  oldFilm: 0,
+  dotFilm: 0,
+  reflectionFilm: 0,
+  glitchFilm: 0,
+  rgbFilm: 0,
+  godrayFilm: 0,
   shockwaveFilter: 0,
   radiusAlphaFilter: 0,
 };


### PR DESCRIPTION
# 介绍

补充 ITransform 接口的属性, 主要是那几个滤镜

- oldFilm
- dotFilm
- reflectionFilm
- rgbFilm
- godrayFilm

连带补充 baseTransform

close #884 
