### PR TITLE
fix: remove animation before set effect

### DIFF
--- a/packages/webgal/src/Core/controller/stage/pixi/PixiController.ts
+++ b/packages/webgal/src/Core/controller/stage/pixi/PixiController.ts
@@ -303,6 +303,11 @@ export default class PixiStage {
     this.removeAnimationByIndex(index);
   }
 
+  public removeAnimationByTargetKey(targetKey: string) {
+    const index = this.stageAnimations.findIndex((e) => e.targetKey === targetKey);
+    this.removeAnimationByIndex(index);
+  }
+
   public removeAnimationWithSetEffects(key: string) {
     const index = this.stageAnimations.findIndex((e) => e.key === key);
     if (index >= 0) {

--- a/packages/webgal/src/Core/controller/stage/pixi/PixiController.ts
+++ b/packages/webgal/src/Core/controller/stage/pixi/PixiController.ts
@@ -304,8 +304,11 @@ export default class PixiStage {
   }
 
   public removeAnimationByTargetKey(targetKey: string) {
-    const index = this.stageAnimations.findIndex((e) => e.targetKey === targetKey);
-    this.removeAnimationByIndex(index);
+    let index = this.stageAnimations.findIndex((e) => e.targetKey === targetKey);
+    while (index !== -1) {
+      this.removeAnimationByIndex(index);
+      index = this.stageAnimations.findIndex((e) => e.targetKey === targetKey);
+    }
   }
 
   public removeAnimationWithSetEffects(key: string) {

--- a/packages/webgal/src/Core/util/syncWithEditor/webSocketFunc.ts
+++ b/packages/webgal/src/Core/util/syncWithEditor/webSocketFunc.ts
@@ -120,6 +120,7 @@ export const webSocketFunc = () => {
             ...(effect.transform?.scale ?? {}),
           },
         };
+        WebGAL.gameplay.pixiStage?.removeAnimationByTargetKey(effect.target);
         webgalStore.dispatch(stageActions.updateEffect({ target: effect.target, transform: newTransform }));
       } catch (e) {
         logger.error(`无法设置效果 ${message.message}, ${e}`);


### PR DESCRIPTION
# 介绍

在触发 SET_EFFECT 调试命令时, 移除正在发生的动画

### Before

https://github.com/user-attachments/assets/6315a430-30a1-4e23-ba21-815efca2dc88

### After

https://github.com/user-attachments/assets/be82e94e-6892-4a3f-b03b-2e09751cc1c6
