### PR TITLE
fix: filter timeline segment

### DIFF
--- a/packages/webgal/src/Core/controller/stage/pixi/animations/timeline.ts
+++ b/packages/webgal/src/Core/controller/stage/pixi/animations/timeline.ts
@@ -29,8 +29,10 @@ export function generateTimelineObj(
     const segmentDuration = segment.duration;
     currentDelay += segmentDuration;
     const { position, scale, ...segmentValues } = segment;
+    // 移除所有值类型不是 number 的属性
+    const filteredSegmentValues = omitBy(segmentValues, (value) => typeof value !== 'number');
     // 不能用 scale，因为 popmotion 不能用嵌套
-    values.push({ x: position?.x, y: position?.y, scaleX: scale?.x, scaleY: scale?.y, ...segmentValues });
+    values.push({ x: position?.x, y: position?.y, scaleX: scale?.x, scaleY: scale?.y, ...filteredSegmentValues });
     // Easing 需要比 values 的长度少一个
     if (i > 0) {
       easeArray.push(stringToEasing(segment.ease));


### PR DESCRIPTION
# 介绍

修复 transform 含有非 number 类型字段时，popmotion 连带游戏卡死的情况

popmotion 似乎只支持 number 和一小部分特定格式的 string，并且只提取第一层属性，其他类型都会报错。position 和 scale 因为已经自行提取出来了，没什么问题

# 更改

在生成 timeline 的 values 前先对每个 segment 过滤掉所有值不是 number 类型的字段。

# 测试

```
changeBg:bg.webp;
changeFigure:stand.png -transform={"postion":{"x":500}}; 这里 position 拼错了，所以会当成普通对象
changeFigure:stand2.png -transform={"aaa":true};
```