### PR TITLE
Chore/align webgal engine manifest v3

### DIFF
--- a/packages/webgal/public/webgal-engine.json
+++ b/packages/webgal/public/webgal-engine.json
@@ -1,5 +1,7 @@
 {
-  "name": "webgal",
+  "schemaVersion": "1.0.0",
+  "id": "open-webgal.webgal",
+  "name": "WebGAL",
   "version": "4.5.18",
   "type": "official",
   "webgalVersion": "4.5.18",
@@ -10,30 +12,12 @@
     "ko": "시각적으로 매력적이며, 기능이 풍부하고, 쉽게 개발할 수 있는 새로운 웹 기반 비주얼 노벨 엔진",
     "fr": "Un moteur de visual novel basé sur le web, attrayant visuellement, riche en fonctionnalités et facile à développer"
   },
-  "author": {
-    "name": "Mahiru",
-    "email": "Mahiru_@outlook.com"
+  "maintainer": {
+    "name": "OpenWebGAL",
+    "email": "contact@openwebgal.com"
   },
   "license": "MPL-2.0",
   "icon": "icons/icon-512.png",
-  "readme": "README.md",
-  "readmes": {
-    "en": "README_EN.md",
-    "ja": "README_JP.md",
-    "ko": "README_KO.md",
-    "fr": "README_FR.md"
-  },
-  "keywords": [
-    "visual-novel",
-    "galgame",
-    "webgal",
-    "game-engine",
-    "web",
-    "official",
-    "original"
-  ],
-  "live2dSupport": false,
-  "spineSupport": false,
   "urls": {
     "homepage": "https://openwebgal.com",
     "repository": "https://github.com/OpenWebGAL/WebGAL",


### PR DESCRIPTION
## 背景

#762 的 RFC 已更新到 v3 版本，官方 manifest 需要同步到这版规范，避免参考实现与规范定义继续漂移。

这次同步主要解决了几个具体问题：

- 官方 manifest 缺少 `schemaVersion` 和 `id`
- `name` 仍然是旧的机器标识风格，而不是正式显示名称
- 人员信息仍使用 `author`，不符合当前修改后的 `maintainer` 语义
- 一些可选字段仍保留旧写法或冗余信息，不符合当前 RFC 的改进方向

## 本次变更

同步更新官方 `packages/webgal/public/webgal-engine.json`：

- 新增 `schemaVersion: "1.0.0"`
- 新增 `id: "open-webgal.webgal"`
- 将 `name` 调整为显示名称 `WebGAL`
- 将人员信息从 `author` 调整为 `maintainer`
  - `name: "OpenWebGAL"`
  - `email: "contact@openwebgal.com"`
- 移除当前不再保留在官方 manifest 中的冗余字段：
  - `readme`
  - `readmes`
  - `keywords`
  - `live2dSupport`
  - `spineSupport`

## 说明

- 引擎根目录下不存在 readme 文件，为避免空引用，移除 `readme` 和 `readmes`
- 根据当前 RFC 语义，`keywords` 不应填写冗余内容，故一并移除
- 根据当前 RFC 语义，`live2dSupport` / `spineSupport` 为可选字段，缺失按 `false` 处理，因此官方 manifest 不再显式填写 `false`