### PR TITLE
fix: 修复非官方引擎在 build 时版本号被错误覆盖的问题

### DIFF
--- a/packages/webgal/scripts/update-engine-version.js
+++ b/packages/webgal/scripts/update-engine-version.js
@@ -26,8 +26,10 @@ try {
   const engineJson = JSON.parse(fs.readFileSync(engineJsonPath, 'utf-8'));
 
   // 更新版本号
-  const oldVersion = engineJson.version;
-  engineJson.version = version;
+  const oldVersion = engineJson.webgalVersion;
+  if (engineJson.type === 'official') {
+    engineJson.version = version;
+  }
   engineJson.webgalVersion = version;
 
   // 写回文件（保持格式化）


### PR DESCRIPTION
添加了对于type字段的判断以解决问题