### PR TITLE
fix: Fix parser vocal named-argument asset resolution

### DIFF
--- a/packages/parser/src/scriptParser/argsParser.ts
+++ b/packages/parser/src/scriptParser/argsParser.ts
@@ -40,36 +40,34 @@ export function argsParser(
         key: argName,
         value: assetSetter(argValue, fileType.vocal),
       });
-    } else {
-      // 判断是不是省略参数
-      if (argValue === undefined) {
-        returnArrayList.push({
-          key: argName,
-          value: true,
-        });
-      } else {
-        // 是字符串描述的布尔值
-        if (argValue === 'true' || argValue === 'false') {
-          returnArrayList.push({
-            key: argName,
-            value: argValue === 'true',
-          });
-        } else {
-          // 是数字
-          if (!isNaN(Number(argValue))) {
-            returnArrayList.push({
-              key: argName,
-              value: Number(argValue),
-            });
-          } else {
-            // 是普通参数
-            returnArrayList.push({
-              key: argName,
-              value: argValue,
-            });
-          }
-        }
-      }
+    }
+    // 判断是不是省略参数
+    else if (argValue === undefined) {
+      returnArrayList.push({
+        key: argName,
+        value: true,
+      });
+    }
+    // 是字符串描述的布尔值
+    else if (argValue === 'true' || argValue === 'false') {
+      returnArrayList.push({
+        key: argName,
+        value: argValue === 'true',
+      });
+    }
+    // 是数字
+    else if (!isNaN(Number(argValue))) {
+      returnArrayList.push({
+        key: argName,
+        value: Number(argValue),
+      });
+    }
+    // 是普通参数
+    else {
+      returnArrayList.push({
+        key: argName,
+        value: argValue,
+      });
     }
   });
   return returnArrayList;

--- a/packages/parser/src/scriptParser/argsParser.ts
+++ b/packages/parser/src/scriptParser/argsParser.ts
@@ -35,6 +35,11 @@ export function argsParser(
         key: 'vocal',
         value: assetSetter(e, fileType.vocal),
       });
+    } else if (argName === 'vocal' && argValue !== undefined) {
+      returnArrayList.push({
+        key: argName,
+        value: assetSetter(argValue, fileType.vocal),
+      });
     } else {
       // 判断是不是省略参数
       if (argValue === undefined) {

--- a/packages/parser/test/parser.test.ts
+++ b/packages/parser/test/parser.test.ts
@@ -202,6 +202,27 @@ test("say statement", async () => {
   expect(result.sentenceList).toContainEqual(expectSentenceItem);
 });
 
+test("say statement applies asset setter to vocal named argument", async () => {
+  const parser = new SceneParser((assetList) => {
+  }, (fileName, assetType) => {
+    if (assetType === fileType.vocal) {
+      return `./game/vocal/${fileName}`;
+    }
+    return fileName;
+  }, ADD_NEXT_ARG_LIST, SCRIPT_CONFIG);
+
+  const result = parser.parse(`say:123 -speaker=xx -vocal=a.mp3;`, 'test', 'test');
+  const sentence = result.sentenceList[0];
+
+  expect(sentence.args).toContainEqual({ key: 'vocal', value: './game/vocal/a.mp3' });
+  expect(sentence.sentenceAssets).toContainEqual({
+    name: './game/vocal/a.mp3',
+    url: './game/vocal/a.mp3',
+    type: fileType.vocal,
+    lineNumber: 0,
+  });
+});
+
 test("wait command", async () => {
   const parser = new SceneParser((assetList) => {
   }, (fileName, assetType) => {


### PR DESCRIPTION
## 背景

当前 parser 对语音参数有两种写法：

- 简写：`-a.mp3`
- 标准写法：`-vocal=a.mp3`

其中简写会经过 `assetSetter`，但标准写法此前会被当作普通字符串参数处理，导致没有补全资源路径，最终无法正确解析语音资源。

## 变更

- 为 `vocal` 命名参数新增独立解析分支
- 让 `-vocal=...` 与简写语法统一走 `assetSetter`
- 补充 parser 回归测试，覆盖 `say:123 -speaker=xx -vocal=a.mp3;`