### PR TITLE
Feat/continue game

### DIFF
--- a/packages/webgal/public/game/config.txt
+++ b/packages/webgal/public/game/config.txt
@@ -4,3 +4,4 @@ Title_img:WebGAL_New_Enter_Image.webp;
 Title_bgm:s_Title.mp3;
 Game_Logo:WebGalEnter.webp;
 Enable_Appreciation:true;
+Enable_Continue:true;

--- a/packages/webgal/src/Core/controller/gamePlay/backToTitle.ts
+++ b/packages/webgal/src/Core/controller/gamePlay/backToTitle.ts
@@ -5,9 +5,11 @@ import { stopAuto } from '@/Core/controller/gamePlay/autoPlay';
 import { stopFast } from '@/Core/controller/gamePlay/fastSkip';
 import { setEbg } from '@/Core/gameScripts/changeBg/setEbg';
 import { stageStateManager } from '@/Core/Modules/stage/stageStateManager';
+import { fastSaveGame } from '../storage/fastSaveLoad';
 
 export const backToTitle = () => {
   if (webgalStore.getState().GUI.showTitle) return;
+  fastSaveGame();
   const dispatch = webgalStore.dispatch;
   stopAllPerform();
   stopAuto();

--- a/packages/webgal/src/Core/controller/gamePlay/startContinueGame.ts
+++ b/packages/webgal/src/Core/controller/gamePlay/startContinueGame.ts
@@ -34,20 +34,9 @@ export async function continueGame() {
    * 重设模糊背景
    */
   setEbg(stageStateManager.getViewStageState().bgName);
-  // 当且仅当游戏未开始时使用快速存档
-  // 当游戏开始后 使用原来的逻辑
-  if ((await hasFastSaveRecord()) && WebGAL.sceneManager.sceneData.currentSentenceId === 0) {
+  if ((await hasFastSaveRecord())) {
+    webgalStore.dispatch(setVisibility({ component: 'showTitle', visibility: false }));
     // 恢复记录
     await loadFastSaveGame();
-    return;
-  }
-  if (
-    WebGAL.sceneManager.sceneData.currentSentenceId === 0 &&
-    WebGAL.sceneManager.sceneData.currentScene.sceneName === 'start.txt'
-  ) {
-    // 如果游戏没有开始，开始游戏
-    nextSentence();
-  } else {
-    restorePerform();
   }
 }

--- a/packages/webgal/src/Core/controller/storage/fastSaveLoad.ts
+++ b/packages/webgal/src/Core/controller/storage/fastSaveLoad.ts
@@ -22,6 +22,11 @@ export function initKey() {
  * 用于紧急回避时的数据存储 & 快速保存
  */
 export async function fastSaveGame() {
+  const showTitle = webgalStore.getState().GUI.showTitle;
+  if (showTitle) {
+    // 如果在标题界面，不进行快速保存
+    return;
+  }
   const saveData: ISaveData = generateCurrentStageData(-1, false);
   const newSaveData = cloneDeep(saveData);
   webgalStore.dispatch(saveActions.setFastSave(newSaveData));
@@ -48,6 +53,7 @@ export async function loadFastSaveGame() {
   if (!loadFile) {
     return;
   }
+  removeFastSaveGameRecord();
   loadGameFromStageData(loadFile);
 }
 
@@ -56,7 +62,5 @@ export async function loadFastSaveGame() {
  */
 export async function removeFastSaveGameRecord() {
   webgalStore.dispatch(saveActions.resetFastSave());
-  await setStorageAsync();
-  // await localforage.setItem(isFastSaveKey, false);
-  // await localforage.setItem(fastSaveGameKey, null);
+  await dumpFastSaveToStorage();
 }

--- a/packages/webgal/src/Core/controller/storage/fastSaveLoad.ts
+++ b/packages/webgal/src/Core/controller/storage/fastSaveLoad.ts
@@ -1,9 +1,10 @@
 import { webgalStore } from '@/store/store';
-import { getStorageAsync, setStorageAsync } from '@/Core/controller/storage/storageController';
+import { getStorageAsync } from '@/Core/controller/storage/storageController';
 import { ISaveData } from '@/store/userDataInterface';
 import { loadGameFromStageData } from '@/Core/controller/storage/loadGame';
 import { generateCurrentStageData } from '@/Core/controller/storage/saveGame';
 import cloneDeep from 'lodash/cloneDeep';
+import throttle from 'lodash/throttle';
 import { WebGAL } from '@/Core/WebGAL';
 import { saveActions } from '@/store/savesReducer';
 import { dumpFastSaveToStorage, getFastSaveFromStorage } from '@/Core/controller/storage/savesController';
@@ -11,6 +12,7 @@ import { dumpFastSaveToStorage, getFastSaveFromStorage } from '@/Core/controller
 export let fastSaveGameKey = '';
 export let isFastSaveKey = '';
 let lock = true;
+let dumpFastSaveTask = Promise.resolve();
 
 export function initKey() {
   lock = false;
@@ -18,20 +20,29 @@ export function initKey() {
   isFastSaveKey = `FastSaveActive-${WebGAL.gameName}-${WebGAL.gameKey}`;
 }
 
+function dumpFastSaveToStorageSerial() {
+  dumpFastSaveTask = dumpFastSaveTask.catch(() => {}).then(dumpFastSaveToStorage);
+  return dumpFastSaveTask;
+}
+
 /**
  * 用于紧急回避时的数据存储 & 快速保存
  */
 export async function fastSaveGame() {
   const showTitle = webgalStore.getState().GUI.showTitle;
-  if (showTitle) {
-    // 如果在标题界面，不进行快速保存
+  if (showTitle || WebGAL.sceneManager.sceneData.currentSentenceId === 0) {
+    // 如果在标题界面或游戏未开始，不进行快速保存
     return;
   }
   const saveData: ISaveData = generateCurrentStageData(-1, false);
   const newSaveData = cloneDeep(saveData);
   webgalStore.dispatch(saveActions.setFastSave(newSaveData));
-  await dumpFastSaveToStorage();
+  await dumpFastSaveToStorageSerial();
 }
+
+export const autoFastSaveGame = throttle(() => {
+  void fastSaveGame();
+}, 1000);
 
 /**
  * 判断是否有无存储紧急回避时的数据
@@ -53,7 +64,6 @@ export async function loadFastSaveGame() {
   if (!loadFile) {
     return;
   }
-  removeFastSaveGameRecord();
   loadGameFromStageData(loadFile);
 }
 
@@ -61,6 +71,7 @@ export async function loadFastSaveGame() {
  * 移除紧急回避的数据
  */
 export async function removeFastSaveGameRecord() {
+  autoFastSaveGame.cancel();
   webgalStore.dispatch(saveActions.resetFastSave());
-  await dumpFastSaveToStorage();
+  await dumpFastSaveToStorageSerial();
 }

--- a/packages/webgal/src/Core/gameScripts/end.ts
+++ b/packages/webgal/src/Core/gameScripts/end.ts
@@ -9,7 +9,7 @@ import { setVisibility } from '@/store/GUIReducer';
 import { playBgm } from '@/Core/controller/stage/playBgm';
 import { WebGAL } from '@/Core/WebGAL';
 import { dumpToStorageFast } from '@/Core/controller/storage/storageController';
-import { saveActions } from '@/store/savesReducer';
+import { removeFastSaveGameRecord } from '../controller/storage/fastSaveLoad';
 
 /**
  * 结束游戏
@@ -24,7 +24,7 @@ export const end = (sentence: ISentence): IPerform => {
   setTimeout(() => {
     WebGAL.sceneManager.resetScene();
   }, 5);
-  dispatch(saveActions.resetFastSave());
+  removeFastSaveGameRecord();
   dumpToStorageFast();
   sceneFetcher(sceneUrl).then((rawScene) => {
     // 场景写入到运行时

--- a/packages/webgal/src/Core/initializeScript.ts
+++ b/packages/webgal/src/Core/initializeScript.ts
@@ -15,6 +15,7 @@ import { __INFO } from '@/config/info';
 import { WebGAL } from '@/Core/WebGAL';
 import { loadTemplate } from '@/Core/util/coreInitialFunction/templateLoader';
 import { stageStateManager } from '@/Core/Modules/stage/stageStateManager';
+import { autoFastSaveGame } from './controller/storage/fastSaveLoad';
 
 export const isIOS = window.__WEBGAL_DEVICE_INFO__?.isIOS ?? false; // 判断是否是 iOS 终端
 
@@ -57,7 +58,10 @@ export const initializeScript = (): void => {
    * 启动Pixi
    */
   WebGAL.gameplay.pixiStage = new PixiStage();
-  stageStateManager.setCommitHandler(syncPixiStageState);
+  stageStateManager.setCommitHandler((stageState, options) => {
+    syncPixiStageState(stageState, options);
+    if (options.notifyReact) autoFastSaveGame();
+  });
 
   /**
    * iOS 设备 卸载所有 Service Worker

--- a/packages/webgal/src/UI/Title/Title.tsx
+++ b/packages/webgal/src/UI/Title/Title.tsx
@@ -16,6 +16,7 @@ import styles from './title.module.scss';
 /** 标题页 */
 export default function Title() {
   const userDataState = useSelector((state: RootState) => state.userData);
+  const userSaveData = useSelector((state: RootState) => state.saveData);
   const GUIState = useSelector((state: RootState) => state.GUI);
   const dispatch = useDispatch();
   const fullScreen = userDataState.optionData.fullScreen;
@@ -24,6 +25,8 @@ export default function Title() {
   const t = useTrans('title.');
   const tCommon = useTrans('common.');
   const { playSeEnter, playSeClick } = useSoundEffect();
+  const fastSaveData = userSaveData.quickSaveData;
+  const enableContinue = userDataState.globalGameVar.Enable_Continue !== false;
 
   const applyStyle = useApplyStyle('title');
   useConfigData(); // 监听基础ConfigData变化
@@ -72,17 +75,22 @@ export default function Title() {
             >
               {renderButtonText(t('start.title'))}
             </div>
-            <div
-              className={applyStyle('Title_button', styles.Title_button)}
-              onClick={async () => {
-                playSeClick();
-                dispatch(setVisibility({ component: 'showTitle', visibility: false }));
-                continueGame();
-              }}
-              onMouseEnter={playSeEnter}
-            >
-              {renderButtonText(t('continue.title'))}
-            </div>
+            {enableContinue && (
+              <div
+                className={`${applyStyle('Title_button', styles.Title_button)} ${
+                  !fastSaveData ? applyStyle('Title_button_disabled', styles.Title_button_disabled) : ''
+                }`}
+                onClick={() => {
+                  if (fastSaveData) {
+                    playSeClick();
+                    continueGame();
+                  }
+                }}
+                onMouseEnter={fastSaveData ? playSeEnter : undefined}
+              >
+                {renderButtonText(t('continue.title'))}
+              </div>
+            )}
             <div
               className={applyStyle('Title_button', styles.Title_button)}
               onClick={() => {


### PR DESCRIPTION
> #958 

本提交旨在优化目前“继续游戏”功能与紧急回避存档的存储与读取逻辑，包含一下变更：

- 新增 Enable_Continue 游戏配置项，用于控制标题页“继续游戏”按钮是否显示。
- “继续游戏”逻辑改为读取最新的普通存档，而不是原先的读取紧急回避存档/开始游戏/回到舞台状态的逻辑。
  - “继续游戏”按钮会在无可用存档时置灰。
- 存档数据新增 `saveTimestamp` 字段，用于更稳定地对存档进行排序（兼容旧存档的 `saveTime` 字段）。
  - 优化紧急回避存档的存储与读取逻辑，仅在非标题界面退出游戏时，保存紧急回避存档。
  - 仅在启动游戏时，检查是否有紧急回避存档，如果有，提示用户是否读取。

