### PR TITLE
fix: avoid cumulative preview set-effect transforms

### DIFF
--- a/packages/webgal/src/Core/util/syncWithEditor/previewSetEffectTransform.ts
+++ b/packages/webgal/src/Core/util/syncWithEditor/previewSetEffectTransform.ts
@@ -1,0 +1,27 @@
+import { baseTransform } from '../../Modules/stage/stageInterface';
+import type { ITransform } from '../../Modules/stage/stageInterface';
+import type { SetEffectPayload } from '../../../types/editorPreviewProtocol';
+
+type SetEffectTransformInput = SetEffectPayload['transform'];
+
+export function mergeSetEffectPreviewTransform(
+  baseline: ITransform,
+  transform?: SetEffectTransformInput,
+): ITransform {
+  return {
+    ...baseline,
+    ...(transform ?? {}),
+    position: {
+      ...baseline.position,
+      ...(transform?.position ?? {}),
+    },
+    scale: {
+      ...baseline.scale,
+      ...(transform?.scale ?? {}),
+    },
+  };
+}
+
+export function normalizeSetEffectPreviewBaseline(transform?: ITransform): ITransform {
+  return mergeSetEffectPreviewTransform(baseTransform, transform);
+}

--- a/packages/webgal/src/Core/util/syncWithEditor/previewSetEffectTransform.ts
+++ b/packages/webgal/src/Core/util/syncWithEditor/previewSetEffectTransform.ts
@@ -1,6 +1,5 @@
-import { baseTransform } from '../../Modules/stage/stageInterface';
-import type { ITransform } from '../../Modules/stage/stageInterface';
-import type { SetEffectPayload } from '../../../types/editorPreviewProtocol';
+import type { ITransform } from '@/Core/Modules/stage/stageInterface';
+import type { SetEffectPayload } from '@/types/editorPreviewProtocol';
 
 type SetEffectTransformInput = SetEffectPayload['transform'];
 
@@ -20,8 +19,4 @@ export function mergeSetEffectPreviewTransform(
       ...(transform?.scale ?? {}),
     },
   };
-}
-
-export function normalizeSetEffectPreviewBaseline(transform?: ITransform): ITransform {
-  return mergeSetEffectPreviewTransform(baseTransform, transform);
 }

--- a/packages/webgal/src/Core/util/syncWithEditor/previewSyncRuntime.ts
+++ b/packages/webgal/src/Core/util/syncWithEditor/previewSyncRuntime.ts
@@ -28,8 +28,11 @@ import { nextSentence } from '@/Core/controller/gamePlay/nextSentence';
 import { resetStage } from '@/Core/controller/stage/resetStage';
 import { logger } from '@/Core/util/logger';
 import { stageStateManager } from '@/Core/Modules/stage/stageStateManager';
-import { baseTransform } from '@/Core/Modules/stage/stageInterface';
-import type { IStageState } from '@/Core/Modules/stage/stageInterface';
+import type { IStageState, ITransform } from '@/Core/Modules/stage/stageInterface';
+import {
+  mergeSetEffectPreviewTransform,
+  normalizeSetEffectPreviewBaseline,
+} from './previewSetEffectTransform';
 import { requestEmbeddedLaunchId } from './runtime/embeddedPreviewBootstrap';
 import {
   createPreviewSyncTransport,
@@ -74,6 +77,7 @@ export const startPreviewSyncRuntime = () => {
   let lastPublishedSceneName: string | null = null;
   let lastPublishedSentenceId: number | null = null;
   let lastPublishedStageState: StageStateSnapshot | null = null;
+  const setEffectBaselines = new Map<string, ITransform>();
   const embeddedLaunchIdPromise = requestEmbeddedLaunchId();
   let transport!: PreviewSyncTransport;
 
@@ -87,6 +91,7 @@ export const startPreviewSyncRuntime = () => {
     lastPublishedSceneName = null;
     lastPublishedSentenceId = null;
     lastPublishedStageState = null;
+    setEffectBaselines.clear();
   };
 
   const buildStageStateSnapshot = (stageState: StageStateSnapshot): StageSnapshotUpdatedPayload['stageState'] => {
@@ -162,10 +167,12 @@ export const startPreviewSyncRuntime = () => {
   };
 
   const handleSyncScene = (payload: SyncScenePayload) => {
+    setEffectBaselines.clear();
     executePreviewSyncSceneCommand(payload, emitFastPreviewTimeout);
   };
 
   const handleRunSnippet = (payload: RunSnippetPayload) => {
+    setEffectBaselines.clear();
     const scene = WebgalParser.parse(payload.snippet, 'temp.txt', 'temp.txt');
     (scene.sentenceList as unknown as ISentence[]).forEach((sentence) => {
       runScript(sentence);
@@ -197,6 +204,7 @@ export const startPreviewSyncRuntime = () => {
   };
 
   const handleRunSceneContent = (payload: RunSceneContentPayload) => {
+    setEffectBaselines.clear();
     resetStage(true);
     WebGAL.sceneManager.sceneData.currentScene = sceneParser(payload.sceneContent, 'temp', './temp.txt');
     applyComponentVisibility({
@@ -222,23 +230,22 @@ export const startPreviewSyncRuntime = () => {
     setDebugTextReadMode(payload.isRead);
   };
 
-  const handleSetEffect = (payload: SetEffectPayload) => {
-    const targetEffect = stageStateManager
+  const getSetEffectBaseline = (target: string) => {
+    const cachedBaseline = setEffectBaselines.get(target);
+    if (cachedBaseline) {
+      return cachedBaseline;
+    }
+
+    const currentTransform = stageStateManager
       .getCalculationStageState()
-      .effects.find((effect) => effect.target === payload.target);
-    const targetTransform = targetEffect?.transform ? targetEffect.transform : baseTransform;
-    const newTransform = {
-      ...targetTransform,
-      ...(payload.transform ?? {}),
-      position: {
-        ...targetTransform.position,
-        ...(payload.transform?.position ?? {}),
-      },
-      scale: {
-        ...targetTransform.scale,
-        ...(payload.transform?.scale ?? {}),
-      },
-    };
+      .effects.find((effect) => effect.target === target)?.transform;
+    const baseline = normalizeSetEffectPreviewBaseline(currentTransform);
+    setEffectBaselines.set(target, baseline);
+    return baseline;
+  };
+
+  const handleSetEffect = (payload: SetEffectPayload) => {
+    const newTransform = mergeSetEffectPreviewTransform(getSetEffectBaseline(payload.target), payload.transform);
     WebGAL.gameplay.pixiStage?.removeAnimationByTargetKey(payload.target);
     stageStateManager.updateEffectAndCommit({
       target: payload.target,

--- a/packages/webgal/src/Core/util/syncWithEditor/previewSyncRuntime.ts
+++ b/packages/webgal/src/Core/util/syncWithEditor/previewSyncRuntime.ts
@@ -28,11 +28,9 @@ import { nextSentence } from '@/Core/controller/gamePlay/nextSentence';
 import { resetStage } from '@/Core/controller/stage/resetStage';
 import { logger } from '@/Core/util/logger';
 import { stageStateManager } from '@/Core/Modules/stage/stageStateManager';
+import { baseTransform } from '@/Core/Modules/stage/stageInterface';
 import type { IStageState, ITransform } from '@/Core/Modules/stage/stageInterface';
-import {
-  mergeSetEffectPreviewTransform,
-  normalizeSetEffectPreviewBaseline,
-} from './previewSetEffectTransform';
+import { mergeSetEffectPreviewTransform } from './previewSetEffectTransform';
 import { requestEmbeddedLaunchId } from './runtime/embeddedPreviewBootstrap';
 import {
   createPreviewSyncTransport,
@@ -233,7 +231,7 @@ export const startPreviewSyncRuntime = () => {
     setDebugTextReadMode(payload.isRead);
   };
 
-  const getSetEffectBaseline = (target: string) => {
+  const getSetEffectBaseline = (target: string): ITransform => {
     const cachedBaseline = setEffectBaselines.get(target);
     if (cachedBaseline) {
       return cachedBaseline;
@@ -242,7 +240,7 @@ export const startPreviewSyncRuntime = () => {
     const currentTransform = stageStateManager
       .getCalculationStageState()
       .effects.find((effect) => effect.target === target)?.transform;
-    const baseline = normalizeSetEffectPreviewBaseline(currentTransform);
+    const baseline = mergeSetEffectPreviewTransform(baseTransform, currentTransform);
     setEffectBaselines.set(target, baseline);
     return baseline;
   };


### PR DESCRIPTION
## 背景

此前 preview `set-effect` 会基于上一次写入后的 transform 继续合并。实时拖拽或局部调整时，未传入的字段会保留上一次 preview 值，导致位置、缩放、滤镜等效果在多次 `set-effect` 之间累积污染，也无法通过空 transform 恢复到本轮预览开始前的状态。

## 概要

- 为 preview `set-effect` 命令按 target 捕获一份 baseline transform。
- 每次收到 `set-effect` 时，都基于 baseline 和当前 payload 计算效果，不再基于上一次 preview 结果累积。
- 在注册状态重置、场景同步、执行 snippet、运行临时场景内容时清空 baseline，避免跨场景污染。

## 行为变化

- 未传入的 transform 字段会回到 baseline，而不是沿用上一次 `set-effect` 的结果。
- `transform: {}` 会把目标恢复到当前 preview 会话捕获到的 baseline。