### PR TITLE
fix: match vocal arg extensions exactly

### DIFF
--- a/packages/parser/src/scriptParser/argsParser.ts
+++ b/packages/parser/src/scriptParser/argsParser.ts
@@ -30,7 +30,7 @@ export function argsParser(
       argValue = undefined;
     }
     // 判断是不是语音参数
-    if (argName.toLowerCase().match(/.ogg|.mp3|.wav/)) {
+    if (/\.(ogg|mp3|wav)$/i.test(argName)) {
       returnArrayList.push({
         key: 'vocal',
         value: assetSetter(e, fileType.vocal),

--- a/packages/parser/test/parser.test.ts
+++ b/packages/parser/test/parser.test.ts
@@ -4,6 +4,7 @@ import { expect, test } from "vitest";
 import { commandType, ISentence } from "../src/interface/sceneInterface";
 import * as fsp from 'fs/promises';
 import { fileType } from "../src/interface/assets";
+import { argsParser } from "../src/scriptParser/argsParser";
 
 test("label", async () => {
 
@@ -54,6 +55,15 @@ test("args", async () => {
     inlineComment: ""
   };
   expect(result.sentenceList).toContainEqual(expectSentenceItem);
+});
+
+test("args parser only treats real audio extensions as vocal args", () => {
+  const result = argsParser(" -sogg -voice.mp3", (fileName, assetType) => {
+    return `${assetType}:${fileName}`;
+  });
+
+  expect(result).toContainEqual({ key: "sogg", value: true });
+  expect(result).toContainEqual({ key: "vocal", value: `${fileType.vocal}:voice.mp3` });
 });
 
 test("choose", async () => {


### PR DESCRIPTION
## Summary\n- tighten vocal argument detection to match real .ogg/.mp3/.wav extensions\n- avoid treating non-audio flag names such as sogg as vocal assets\n- add parser coverage for the extension check\n\n## Testing\n- cd packages/parser && yarn vitest run parser.test.ts