### PR TITLE
fix(parser): preserve semicolons in inline comments

### DIFF
--- a/packages/parser/src/scriptParser/scriptParser.ts
+++ b/packages/parser/src/scriptParser/scriptParser.ts
@@ -40,7 +40,7 @@ export const scriptParser = (
   const commentSplit = sentenceRaw.split(/(?<!\\);/);
   let newSentenceRaw = commentSplit[0];
   newSentenceRaw = newSentenceRaw.replaceAll('\\;',';');
-  const sentenceComment = commentSplit[1] ?? '';
+  const sentenceComment = commentSplit.slice(1).join(';');
   if (newSentenceRaw.trim() === '') {
     // 注释提前返回
     return {

--- a/packages/parser/test/parser.test.ts
+++ b/packages/parser/test/parser.test.ts
@@ -326,6 +326,25 @@ test("escaped semicolon is preserved in content and inline comment is preserved"
   expect(result.sentenceList).toContainEqual(expectSentenceItem);
 });
 
+test("inline comment preserves following semicolons", async () => {
+  const parser = new SceneParser((assetList) => {
+  }, (fileName, assetType) => {
+    return fileName;
+  }, ADD_NEXT_ARG_LIST, SCRIPT_CONFIG);
+
+  const result = parser.parse(`say:123; first; second; third`, 'test', 'test');
+  const expectSentenceItem: ISentence = {
+    command: commandType.say,
+    commandRaw: "say",
+    content: "123",
+    args: [],
+    sentenceAssets: [],
+    subScene: [],
+    inlineComment: "first; second; third"
+  };
+  expect(result.sentenceList).toContainEqual(expectSentenceItem);
+});
+
 test("comment-only line keeps comment in content", async () => {
   const parser = new SceneParser((assetList) => {
   }, (fileName, assetType) => {
@@ -337,6 +356,25 @@ test("comment-only line keeps comment in content", async () => {
     command: commandType.comment,
     commandRaw: "comment",
     content: "only comment here",
+    args: [{ key: 'next', value: true }],
+    sentenceAssets: [],
+    subScene: [],
+    inlineComment: ""
+  };
+  expect(result.sentenceList).toContainEqual(expectSentenceItem);
+});
+
+test("comment-only line preserves following semicolons", async () => {
+  const parser = new SceneParser((assetList) => {
+  }, (fileName, assetType) => {
+    return fileName;
+  }, ADD_NEXT_ARG_LIST, SCRIPT_CONFIG);
+
+  const result = parser.parse(`; first; second; third`, 'test', 'test');
+  const expectSentenceItem: ISentence = {
+    command: commandType.comment,
+    commandRaw: "comment",
+    content: "first; second; third",
     args: [{ key: 'next', value: true }],
     sentenceAssets: [],
     subScene: [],


### PR DESCRIPTION
> #981 

修正存在多个 `;` 时，行内注释未正确截取的问题