### PR TITLE
fix: validate scene file extension

### DIFF
--- a/packages/webgal/src/Core/controller/scene/sceneFetcher.ts
+++ b/packages/webgal/src/Core/controller/scene/sceneFetcher.ts
@@ -6,7 +6,13 @@ import axios from 'axios';
  */
 export const sceneFetcher = (sceneUrl: string) => {
   return new Promise<string>((resolve, reject) => {
-    if (!sceneUrl.endsWith('.txt')) {
+    let scenePath = '';
+    try {
+      scenePath = sceneUrl ? new URL(sceneUrl, window.location.href).pathname : '';
+    } catch {
+      scenePath = '';
+    }
+    if (!scenePath.endsWith('.txt')) {
       reject('Scene file must be a txt file');
       return;
     }

--- a/packages/webgal/src/Core/controller/scene/sceneFetcher.ts
+++ b/packages/webgal/src/Core/controller/scene/sceneFetcher.ts
@@ -6,6 +6,10 @@ import axios from 'axios';
  */
 export const sceneFetcher = (sceneUrl: string) => {
   return new Promise<string>((resolve, reject) => {
+    if (!sceneUrl.endsWith('.txt')) {
+      reject('Scene file must be a txt file');
+      return;
+    }
     axios
       .get(sceneUrl)
       .then((response) => {


### PR DESCRIPTION
fixes: #980 

获取场景的函数没有对传入的sceneUrl做校验，导致传入空字符串时，请求的是自身的url地址即获取到了当前的html代码。