### PR TITLE
fix: conditionally enable video skip on double click

### DIFF
--- a/packages/webgal/src/Core/gameScripts/playVideo.tsx
+++ b/packages/webgal/src/Core/gameScripts/playVideo.tsx
@@ -37,6 +37,7 @@ export const playVideo = (sentence: ISentence): IPerform => {
     ReactDOM.render(<div />, document.getElementById('videoContainer'));
   };
   const endPerform = () => {
+    if (isOver) return;
     isOver = true;
     WebGAL.gameplay.performController.unmountPerform(performInitName);
   };
@@ -75,14 +76,12 @@ export const playVideo = (sentence: ISentence): IPerform => {
             vocalElement.volume = '0';
           }
 
-          VocalControl?.play().catch(() => {});
+          VocalControl.addEventListener('error', () => endPerform());
+          VocalControl.addEventListener('ended', () => endPerform());
+          VocalControl.play().catch(() => endPerform());
           if (!blockingNextFlag) {
             WebGAL.events.fullscreenDbClick.on(skipVideo);
           }
-
-          VocalControl.onended = () => {
-            endPerform();
-          };
         }
       }, 1);
     },

--- a/packages/webgal/src/Core/gameScripts/playVideo.tsx
+++ b/packages/webgal/src/Core/gameScripts/playVideo.tsx
@@ -63,8 +63,6 @@ export const playVideo = (sentence: ISentence): IPerform => {
         if (VocalControl !== null) {
           VocalControl.currentTime = 0;
           VocalControl.volume = bgmVol;
-          // 双击可跳过视频
-          WebGAL.events.fullscreenDbClick.on(skipVideo);
           /**
            * 把bgm和语音的音量设为0
            */
@@ -78,6 +76,9 @@ export const playVideo = (sentence: ISentence): IPerform => {
           }
 
           VocalControl?.play().catch(() => {});
+          if (!blockingNextFlag) {
+            WebGAL.events.fullscreenDbClick.on(skipVideo);
+          }
 
           VocalControl.onended = () => {
             endPerform();


### PR DESCRIPTION
fixes: https://github.com/OpenWebGAL/WebGAL/issues/985

双击是通过事件直接调用 skipVideo → endPerform()，绕过了场景控制器的判断，设置blockingNext无法阻止。


不过我看之前改脚本这块的逻辑好像大致也是这样的，是改了演出系统的原因才导致失效的嘛...