### PR TITLE
Fix transform frame parsing for empty and non-object input

### DIFF
--- a/packages/webgal/src/Core/gameScripts/changeBg/index.ts
+++ b/packages/webgal/src/Core/gameScripts/changeBg/index.ts
@@ -15,6 +15,7 @@ import { WebGAL } from '@/Core/WebGAL';
 import { DEFAULT_BG_OUT_DURATION } from '@/Core/constants';
 import localforage from 'localforage';
 import { stageStateManager } from '@/Core/Modules/stage/stageStateManager';
+import { parseTransformFrame } from '../parseTransformFrame';
 
 /**
  * 进行背景图片的切换
@@ -56,29 +57,15 @@ export const changeBg = (sentence: ISentence): IPerform => {
 
   // 处理 transform 和 默认 transform
   let animationObj: AnimationFrame[];
-  if (transformString) {
-    try {
-      const frame = JSON.parse(transformString.toString()) as AnimationFrame;
-      animationObj = generateTransformAnimationObj('bg-main', frame, enterDuration, ease, !ignoreDefault);
-      // 因为是切换，必须把一开始的 alpha 改为 0
-      animationObj[0].alpha = 0;
-      const animationName = (Math.random() * 10).toString(16);
-      const newAnimation: IUserAnimation = { name: animationName, effects: animationObj };
-      WebGAL.animationManager.addAnimation(newAnimation);
-      duration = getAnimateDuration(animationName);
-      stageStateManager.updateAnimationSettings({ target: 'bg-main', key: 'enterAnimationName', value: animationName });
-    } catch (e) {
-      // 解析都错误了，歇逼吧
-      applyDefaultTransform();
-    }
+  const frame = transformString ? parseTransformFrame(transformString) : null;
+  if (frame) {
+    applyTransform(frame);
   } else {
     applyDefaultTransform();
   }
 
-  function applyDefaultTransform() {
-    // 应用默认的
-    const frame = {};
-    animationObj = generateTransformAnimationObj('bg-main', frame as AnimationFrame, duration, ease, !ignoreDefault);
+  function applyTransform(frame: AnimationFrame) {
+    animationObj = generateTransformAnimationObj('bg-main', frame, enterDuration, ease, !ignoreDefault);
     // 因为是切换，必须把一开始的 alpha 改为 0
     animationObj[0].alpha = 0;
     const animationName = (Math.random() * 10).toString(16);
@@ -86,6 +73,12 @@ export const changeBg = (sentence: ISentence): IPerform => {
     WebGAL.animationManager.addAnimation(newAnimation);
     duration = getAnimateDuration(animationName);
     stageStateManager.updateAnimationSettings({ target: 'bg-main', key: 'enterAnimationName', value: animationName });
+  }
+
+  function applyDefaultTransform() {
+    // 应用默认的
+    const frame = {};
+    applyTransform(frame as AnimationFrame);
   }
   stageStateManager.updateAnimationSettings({
     target: 'bg-main',

--- a/packages/webgal/src/Core/gameScripts/changeFigure.ts
+++ b/packages/webgal/src/Core/gameScripts/changeFigure.ts
@@ -12,6 +12,7 @@ import { WebGAL } from '@/Core/WebGAL';
 import { baseBlinkParam, baseFocusParam, BlinkParam, FocusParam } from '@/Core/live2DCore';
 import { DEFAULT_FIG_IN_DURATION, DEFAULT_FIG_OUT_DURATION, WEBGAL_NONE } from '../constants';
 import { stageStateManager } from '@/Core/Modules/stage/stageStateManager';
+import { parseTransformFrame } from './parseTransformFrame';
 /**
  * 更改立绘
  * @param sentence 语句
@@ -161,30 +162,15 @@ export function changeFigure(sentence: ISentence): IPerform {
     }
     // 处理 transform 和 默认 transform
     let animationObj: AnimationFrame[];
-    if (transformString) {
-      console.log(transformString);
-      try {
-        const frame = JSON.parse(transformString) as AnimationFrame;
-        animationObj = generateTransformAnimationObj(key, frame, duration, ease, !ignoreDefault);
-        // 因为是切换，必须把一开始的 alpha 改为 0
-        animationObj[0].alpha = 0;
-        const animationName = (Math.random() * 10).toString(16);
-        const newAnimation: IUserAnimation = { name: animationName, effects: animationObj };
-        WebGAL.animationManager.addAnimation(newAnimation);
-        duration = getAnimateDuration(animationName);
-        stageStateManager.updateAnimationSettings({ target: key, key: 'enterAnimationName', value: animationName });
-      } catch (e) {
-        // 解析都错误了，歇逼吧
-        applyDefaultTransform();
-      }
+    const frame = transformString ? parseTransformFrame(transformString) : null;
+    if (frame) {
+      applyTransform(frame);
     } else {
       applyDefaultTransform();
     }
 
-    function applyDefaultTransform() {
-      // 应用默认的
-      const frame = {};
-      animationObj = generateTransformAnimationObj(key, frame as AnimationFrame, duration, ease, !ignoreDefault);
+    function applyTransform(frame: AnimationFrame) {
+      animationObj = generateTransformAnimationObj(key, frame, duration, ease, !ignoreDefault);
       // 因为是切换，必须把一开始的 alpha 改为 0
       animationObj[0].alpha = 0;
       const animationName = (Math.random() * 10).toString(16);
@@ -192,6 +178,12 @@ export function changeFigure(sentence: ISentence): IPerform {
       WebGAL.animationManager.addAnimation(newAnimation);
       duration = getAnimateDuration(animationName);
       stageStateManager.updateAnimationSettings({ target: key, key: 'enterAnimationName', value: animationName });
+    }
+
+    function applyDefaultTransform() {
+      // 应用默认的
+      const frame = {};
+      applyTransform(frame as AnimationFrame);
     }
     stageStateManager.updateAnimationSettings({
       target: key,

--- a/packages/webgal/src/Core/gameScripts/parseTransformFrame.ts
+++ b/packages/webgal/src/Core/gameScripts/parseTransformFrame.ts
@@ -1,0 +1,21 @@
+import { AnimationFrame } from '@/Core/Modules/animations';
+
+export function parseTransformFrame(raw: string): AnimationFrame | null {
+  const source = raw.trim();
+  if (source === '') return null;
+
+  try {
+    const parsed: unknown = JSON.parse(source);
+    return isTransformFrame(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function parseSetTransformFrame(raw: string): AnimationFrame | null {
+  return parseTransformFrame(raw.trim() === '' ? '{}' : raw);
+}
+
+function isTransformFrame(value: unknown): value is AnimationFrame {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/webgal/src/Core/gameScripts/setTransform.ts
+++ b/packages/webgal/src/Core/gameScripts/setTransform.ts
@@ -9,6 +9,7 @@ import { WebGAL } from '@/Core/WebGAL';
 import { applyAnimationEndState, getAnimateDuration } from '../Modules/animationFunctions';
 import { v4 as uuid } from 'uuid';
 import { generateTimelineObj } from '@/Core/controller/stage/pixi/animations/timeline';
+import { parseSetTransformFrame } from './parseTransformFrame';
 /**
  * 设置变换
  * @param sentence
@@ -31,12 +32,10 @@ export const setTransform = (sentence: ISentence): IPerform => {
 
   if (!parallel) WebGAL.gameplay.performController.unmountPerform(performInitName, true);
 
-  try {
-    const frame = JSON.parse(animationString) as AnimationFrame;
+  const frame = parseSetTransformFrame(animationString);
+  if (frame) {
     animationObj = generateTransformAnimationObj(target, frame, duration, ease, writeFullEffect);
-    console.log('animationObj:', animationObj);
-  } catch (e) {
-    // 解析都错误了，歇逼吧
+  } else {
     animationObj = [];
   }
 


### PR DESCRIPTION
## 概要

- 将空的 `setTransform:` 内容按空变换帧处理，使其与 `setTransform:{}` 在 `-writeDefault` 下语义一致。
- 为 `setTransform`、`changeFigure -transform`、`changeBg -transform` 增加统一的 transform frame 解析边界。
- transform frame 现在只接受普通 JSON 对象；数组、数字、布尔值、非法 JSON 都不会进入动画帧。
- `changeFigure` / `changeBg` 的无效 transform 输入会走默认 transform 路径。
- 未修改 parser 的全局参数解析行为，避免影响 `-duration=`、`-zIndex=` 等历史语义。

## 背景

解决 #984

此前 `setTransform:{} -writeDefault` 和 `setTransform: -writeDefault` 行为不一致。原因是空内容会 JSON 解析失败，并被处理成空动画列表，导致默认 transform 终态没有写入。

另外，`changeFigure` / `changeBg` 的 `-transform` 参数缺少对象形态校验，数组或 primitive JSON 可能被当作动画帧进入后续流程。