### PR TITLE
feat: callScene supports args

### DIFF
--- a/packages/parser/src/config/scriptConfig.ts
+++ b/packages/parser/src/config/scriptConfig.ts
@@ -39,6 +39,7 @@ export const SCRIPT_CONFIG = [
   { scriptString: 'applyStyle', scriptType: commandType.applyStyle },
   { scriptString: 'wait', scriptType: commandType.wait },
   { scriptString: 'callSteam', scriptType: commandType.callSteam },
+  { scriptString: 'return', scriptType: commandType.return },
 ];
 export const ADD_NEXT_ARG_LIST = [
   commandType.bgm,

--- a/packages/parser/src/interface/runtimeInterface.ts
+++ b/packages/parser/src/interface/runtimeInterface.ts
@@ -6,6 +6,8 @@ export interface sceneEntry {
   sceneName: string; // 场景名称
   sceneUrl: string; // 场景url
   continueLine: number; // 继续原场景的行号
+  locals?: Record<string, any>; // 该帧的局部变量
+  writeReturnTo?: string; // 返回值写回该帧的哪个变量
 }
 
 /**

--- a/packages/parser/src/interface/sceneInterface.ts
+++ b/packages/parser/src/interface/sceneInterface.ts
@@ -40,6 +40,7 @@ export enum commandType {
   applyStyle,
   wait,
   callSteam, // 调用Steam功能
+  return, // 从被调用的场景返回
 }
 
 /**

--- a/packages/webgal/src/Core/Modules/backlog.ts
+++ b/packages/webgal/src/Core/Modules/backlog.ts
@@ -57,6 +57,7 @@ export class BacklogManager {
         sceneStack: cloneDeep(this.sceneManager.sceneData.sceneStack), // 场景栈
         sceneName: this.sceneManager.sceneData.currentScene.sceneName, // 场景名称
         sceneUrl: this.sceneManager.sceneData.currentScene.sceneUrl, // 场景url
+        currentLocals: cloneDeep(this.sceneManager.sceneData.currentLocals), // 当前帧的局部变量
       },
     };
     this.getBacklog().push(backlogElement);

--- a/packages/webgal/src/Core/Modules/scene.ts
+++ b/packages/webgal/src/Core/Modules/scene.ts
@@ -1,10 +1,18 @@
 import { ISceneData } from '@/Core/controller/scene/sceneInterface';
+import { IGameVar } from '@/Core/Modules/stage/stageInterface';
 import cloneDeep from 'lodash/cloneDeep';
+
+/**
+ * 场景栈的深度上限，防止 callScene 无限递归
+ */
+export const MAX_SCENE_STACK_DEPTH = 64;
 
 export interface ISceneEntry {
   sceneName: string; // 场景名称
   sceneUrl: string; // 场景url
   continueLine: number; // 继续原场景的行号
+  locals?: IGameVar; // 该帧的局部变量
+  writeReturnTo?: string; // 返回值写回该帧的哪个变量
 }
 
 /**
@@ -21,6 +29,7 @@ export const initSceneData = {
     assetsList: [], // 资源列表
     subSceneList: [], // 子场景列表
   },
+  currentLocals: {}, // 当前帧的局部变量
 };
 
 export class SceneManager {
@@ -34,8 +43,37 @@ export class SceneManager {
     this.sceneData.currentSentenceId = 0;
     this.sceneData.sceneStack = [];
     this.sceneData.currentScene = cloneDeep(initSceneData.currentScene);
+    this.sceneData.currentLocals = {};
     this.sceneWritePromise = null;
     this.settledScenes.clear();
     this.settledAssets.clear();
+  }
+
+  /**
+   * 压入一个调用帧。把当前帧（调用方）存进场景栈，并切换到被调用场景的局部变量。
+   * 场景栈与 currentLocals 是同一个栈的两截，必须经由本方法与 popFrame 一起变更。
+   * @param locals 被调用场景的局部变量
+   * @param writeReturnTo 返回值写回当前帧的哪个变量
+   */
+  public pushFrame(locals: IGameVar, writeReturnTo?: string) {
+    this.sceneData.sceneStack.push({
+      sceneName: this.sceneData.currentScene.sceneName,
+      sceneUrl: this.sceneData.currentScene.sceneUrl,
+      continueLine: this.sceneData.currentSentenceId,
+      locals: this.sceneData.currentLocals,
+      writeReturnTo,
+    });
+    this.sceneData.currentLocals = locals;
+  }
+
+  /**
+   * 弹出一个调用帧，并恢复调用方的局部变量。栈为空时返回 undefined。
+   */
+  public popFrame(): ISceneEntry | undefined {
+    const entry = this.sceneData.sceneStack.pop();
+    if (entry) {
+      this.sceneData.currentLocals = entry.locals ?? {}; // 旧存档的栈条目没有 locals
+    }
+    return entry;
   }
 }

--- a/packages/webgal/src/Core/controller/gamePlay/scriptExecutor.ts
+++ b/packages/webgal/src/Core/controller/gamePlay/scriptExecutor.ts
@@ -1,12 +1,11 @@
 import { commandType, ISentence } from '@/Core/controller/scene/sceneInterface';
 import { runScript } from './runScript';
 import { logger } from '../../util/logger';
-import { restoreScene } from '../scene/restoreScene';
+import { returnFromScene } from '../scene/returnFromScene';
 import { webgalStore } from '@/store/store';
 import { getValueFromStateElseKey } from '@/Core/gameScripts/setVar';
 import { strIf } from '@/Core/controller/gamePlay/strIf';
 import cloneDeep from 'lodash/cloneDeep';
-import { ISceneEntry } from '@/Core/Modules/scene';
 import { WebGAL } from '@/Core/WebGAL';
 import { getBooleanArgByKey, getStringArgByKey } from '@/Core/util/getSentenceArg';
 import { stageStateManager } from '@/Core/Modules/stage/stageStateManager';
@@ -61,12 +60,8 @@ export const scriptExecutor = (depth = 0, options: ScriptExecutionOptions = {}) 
     WebGAL.sceneManager.sceneData.currentSentenceId >
     WebGAL.sceneManager.sceneData.currentScene.sentenceList.length - 1
   ) {
-    if (WebGAL.sceneManager.sceneData.sceneStack.length !== 0 && !WebGAL.sceneManager.lockSceneWrite) {
-      const sceneToRestore: ISceneEntry | undefined = WebGAL.sceneManager.sceneData.sceneStack.pop();
-      if (sceneToRestore !== undefined) {
-        restoreScene(sceneToRestore);
-      }
-    }
+    // 没有 return 语句而自然结束，返回空值
+    returnFromScene();
     return;
   }
   const sentenceId = WebGAL.sceneManager.sceneData.currentSentenceId;

--- a/packages/webgal/src/Core/controller/scene/callScene.ts
+++ b/packages/webgal/src/Core/controller/scene/callScene.ts
@@ -5,25 +5,29 @@ import { continueSentence } from '@/Core/controller/gamePlay/nextSentence';
 import { clearPrefetchLinks } from '@/Core/util/prefetcher/assetsPrefetcher';
 
 import { WebGAL } from '@/Core/WebGAL';
+import { IGameVar } from '@/Core/Modules/stage/stageInterface';
+import { MAX_SCENE_STACK_DEPTH } from '@/Core/Modules/scene';
 
 /**
  * 调用场景
  * @param sceneUrl 场景路径
  * @param sceneName 场景名称
+ * @param locals 传入被调用场景的局部变量
+ * @param writeReturnTo 返回值写回本场景的哪个变量
  */
-export const callScene = (sceneUrl: string, sceneName: string) => {
+export const callScene = (sceneUrl: string, sceneName: string, locals: IGameVar = {}, writeReturnTo?: string) => {
   if (WebGAL.sceneManager.lockSceneWrite) {
+    return;
+  }
+  if (WebGAL.sceneManager.sceneData.sceneStack.length >= MAX_SCENE_STACK_DEPTH) {
+    logger.error(`场景调用层数超过 ${MAX_SCENE_STACK_DEPTH}，可能存在 callScene 无限递归`, sceneUrl);
     return;
   }
   WebGAL.sceneManager.lockSceneWrite = true;
   const isFastPreviewSceneWrite = WebGAL.gameplay.isFastPreview;
   let shouldAutoNext = false;
   // 先将本场景压入场景栈
-  WebGAL.sceneManager.sceneData.sceneStack.push({
-    sceneName: WebGAL.sceneManager.sceneData.currentScene.sceneName,
-    sceneUrl: WebGAL.sceneManager.sceneData.currentScene.sceneUrl,
-    continueLine: WebGAL.sceneManager.sceneData.currentSentenceId,
-  });
+  WebGAL.sceneManager.pushFrame(locals, writeReturnTo);
   // 场景写入到运行时
   const sceneWritePromise = sceneFetcher(sceneUrl)
     .then((rawScene) => {

--- a/packages/webgal/src/Core/controller/scene/callScene.ts
+++ b/packages/webgal/src/Core/controller/scene/callScene.ts
@@ -40,6 +40,8 @@ export const callScene = (sceneUrl: string, sceneName: string, locals: IGameVar 
       shouldAutoNext = !isFastPreviewSceneWrite;
     })
     .catch((e) => {
+      // 场景没写进来，之前压入的帧要弹回去，否则调用方会带着被调用方的局部变量继续跑
+      WebGAL.sceneManager.popFrame();
       logger.error('场景调用错误', e);
     })
     .finally(() => {

--- a/packages/webgal/src/Core/controller/scene/returnFromScene.ts
+++ b/packages/webgal/src/Core/controller/scene/returnFromScene.ts
@@ -1,0 +1,24 @@
+import { restoreScene } from './restoreScene';
+import { setGameVar } from '@/Core/gameScripts/setVar';
+
+import { WebGAL } from '@/Core/WebGAL';
+
+/**
+ * 从被调用的场景返回：弹出调用帧，把返回值写回调用方，再恢复调用方场景。
+ * 场景栈为空（顶层场景）或场景正在写入时不做任何事。
+ * @param returnValue 返回值，没有 return 语句而自然结束时为空值
+ */
+export const returnFromScene = (returnValue: string | boolean | number = '') => {
+  // 必须在弹栈之前判定，否则 restoreScene 提前返回会丢掉这一帧
+  if (WebGAL.sceneManager.lockSceneWrite) {
+    return;
+  }
+  const entry = WebGAL.sceneManager.popFrame();
+  if (!entry) {
+    return;
+  }
+  if (entry.writeReturnTo) {
+    setGameVar({ key: entry.writeReturnTo, value: returnValue });
+  }
+  restoreScene(entry);
+};

--- a/packages/webgal/src/Core/controller/scene/sceneInterface.ts
+++ b/packages/webgal/src/Core/controller/scene/sceneInterface.ts
@@ -3,6 +3,7 @@
  */
 import { fileType } from '@/Core/util/gameAssetsAccess/assetSetter';
 import { ISceneEntry } from '@/Core/Modules/scene';
+import { IGameVar } from '@/Core/Modules/stage/stageInterface';
 
 export enum commandType {
   say, // 对话
@@ -40,6 +41,7 @@ export enum commandType {
   applyStyle,
   wait,
   callSteam, // 调用Steam功能
+  return, // 从被调用的场景返回
 }
 
 /**
@@ -96,6 +98,7 @@ export interface ISceneData {
   currentSentenceId: number; // 当前语句ID
   sceneStack: Array<ISceneEntry>; // 场景栈
   currentScene: IScene; // 当前场景数据
+  currentLocals: IGameVar; // 当前帧的局部变量
 }
 
 /**

--- a/packages/webgal/src/Core/controller/storage/fastSaveLoad.ts
+++ b/packages/webgal/src/Core/controller/storage/fastSaveLoad.ts
@@ -30,8 +30,8 @@ function dumpFastSaveToStorageSerial() {
  */
 export async function fastSaveGame() {
   const showTitle = webgalStore.getState().GUI.showTitle;
-  if (showTitle || WebGAL.sceneManager.sceneData.currentSentenceId === 0) {
-    // 如果在标题界面或游戏未开始，不进行快速保存
+  if (showTitle || WebGAL.sceneManager.sceneData.currentSentenceId === 0 || WebGAL.sceneManager.lockSceneWrite) {
+    // 如果在标题界面、游戏未开始或场景正在写入（此时状态是撕裂的），不进行快速保存
     return;
   }
   const saveData: ISaveData = generateCurrentStageData(-1, false);

--- a/packages/webgal/src/Core/controller/storage/jumpFromBacklog.ts
+++ b/packages/webgal/src/Core/controller/storage/jumpFromBacklog.ts
@@ -54,6 +54,7 @@ export const jumpFromBacklog = (index: number, refetchScene = true) => {
     });
   WebGAL.sceneManager.sceneData.currentSentenceId = backlogFile.saveScene.currentSentenceId;
   WebGAL.sceneManager.sceneData.sceneStack = cloneDeep(backlogFile.saveScene.sceneStack);
+  WebGAL.sceneManager.sceneData.currentLocals = cloneDeep(backlogFile.saveScene.currentLocals ?? {}); // 旧存档没有此字段
 
   // 强制停止所有演出
   stopAllPerform();

--- a/packages/webgal/src/Core/controller/storage/loadGame.ts
+++ b/packages/webgal/src/Core/controller/storage/loadGame.ts
@@ -42,6 +42,7 @@ export function loadGameFromStageData(stageData: ISaveData) {
   });
   WebGAL.sceneManager.sceneData.currentSentenceId = loadFile.sceneData.currentSentenceId;
   WebGAL.sceneManager.sceneData.sceneStack = cloneDeep(loadFile.sceneData.sceneStack);
+  WebGAL.sceneManager.sceneData.currentLocals = cloneDeep(loadFile.sceneData.currentLocals ?? {}); // 旧存档没有此字段
 
   // 强制停止所有演出
   stopAllPerform();

--- a/packages/webgal/src/Core/controller/storage/saveGame.ts
+++ b/packages/webgal/src/Core/controller/storage/saveGame.ts
@@ -15,6 +15,11 @@ import { stageStateManager } from '@/Core/Modules/stage/stageStateManager';
  * @param index 游戏的档位
  */
 export const saveGame = (index: number) => {
+  if (WebGAL.sceneManager.lockSceneWrite) {
+    // 场景写入期间状态是撕裂的：场景栈已变更，但当前场景与语句ID尚未切换
+    logger.warn('场景切换中，忽略本次存档');
+    return;
+  }
   const saveData: ISaveData = generateCurrentStageData(index);
   webgalStore.dispatch(saveActions.saveGame({ index, saveData }));
   dumpSavesToStorage(index, index);
@@ -54,6 +59,7 @@ export function generateCurrentStageData(index: number, isSavePreviewImage = tru
       sceneStack: cloneDeep(WebGAL.sceneManager.sceneData.sceneStack), // 场景栈
       sceneName: WebGAL.sceneManager.sceneData.currentScene.sceneName, // 场景名称
       sceneUrl: WebGAL.sceneManager.sceneData.currentScene.sceneUrl, // 场景url
+      currentLocals: cloneDeep(WebGAL.sceneManager.sceneData.currentLocals), // 当前帧的局部变量
     },
     previewImage: urlToSave,
   };

--- a/packages/webgal/src/Core/gameScripts/callSceneScript.ts
+++ b/packages/webgal/src/Core/gameScripts/callSceneScript.ts
@@ -1,6 +1,18 @@
 import { ISentence } from '@/Core/controller/scene/sceneInterface';
 import { createNonePerform, IPerform } from '@/Core/Modules/perform/performInterface';
+import { IGameVar } from '@/Core/Modules/stage/stageInterface';
 import { callScene } from '../controller/scene/callScene';
+
+/**
+ * 还原参数值的类型。参数经过变量插值后恒为字符串，这里按解析器的规则重新判定。
+ * @see packages/parser/src/scriptParser/argsParser.ts
+ */
+const restoreArgValueType = (value: string | boolean | number) => {
+  if (typeof value !== 'string') return value;
+  if (value === 'true' || value === 'false') return value === 'true';
+  if (!isNaN(Number(value))) return Number(value);
+  return value;
+};
 
 /**
  * 调用一个场景，在场景结束后回到调用这个场景的父场景。
@@ -9,6 +21,15 @@ import { callScene } from '../controller/scene/callScene';
 export const callSceneScript = (sentence: ISentence): IPerform => {
   const sceneNameArray: Array<string> = sentence.content.split('/');
   const sceneName = sceneNameArray[sceneNameArray.length - 1];
-  callScene(sentence.content, sceneName);
+  // 所有参数原样成为被调用场景的局部变量，包括 when、next 等通用参数，子场景用不用随意
+  const locals: IGameVar = {};
+  let writeReturnTo: string | undefined;
+  sentence.args.forEach(({ key, value }) => {
+    locals[key] = restoreArgValueType(value);
+    if (key === 'writeReturnTo' && typeof value === 'string') {
+      writeReturnTo = value;
+    }
+  });
+  callScene(sentence.content, sceneName, locals, writeReturnTo);
   return createNonePerform({ isHoldOn: true });
 };

--- a/packages/webgal/src/Core/gameScripts/returnScript.ts
+++ b/packages/webgal/src/Core/gameScripts/returnScript.ts
@@ -1,0 +1,15 @@
+import { ISentence } from '@/Core/controller/scene/sceneInterface';
+import { createNonePerform, IPerform } from '@/Core/Modules/perform/performInterface';
+import { returnFromScene } from '@/Core/controller/scene/returnFromScene';
+import { resolveSetVarValue } from './setVar';
+
+/**
+ * 从被调用的场景返回，可携带返回值。返回值在被调用场景的作用域内求值。
+ * @param sentence
+ */
+export const returnScript = (sentence: ISentence): IPerform => {
+  // 不写冒号时（`return;`）解析器会把整条命令留在 content 里，此时视为无返回值
+  const valExp = sentence.content === sentence.commandRaw ? '' : sentence.content;
+  returnFromScene(resolveSetVarValue(valExp));
+  return createNonePerform({ isHoldOn: true });
+};

--- a/packages/webgal/src/Core/gameScripts/setVar.ts
+++ b/packages/webgal/src/Core/gameScripts/setVar.ts
@@ -11,6 +11,7 @@ import get from 'lodash/get';
 import random from 'lodash/random';
 import { getBooleanArgByKey } from '../util/getSentenceArg';
 import { stageStateManager } from '@/Core/Modules/stage/stageStateManager';
+import { WebGAL } from '@/Core/WebGAL';
 
 interface ISetGameVarFromExpressionPayload {
   key: string;
@@ -18,6 +19,17 @@ interface ISetGameVarFromExpressionPayload {
   isGlobal?: boolean;
   persistGlobal?: boolean;
 }
+
+/**
+ * 写入游戏变量。setVar 与场景返回值共用这一条写入路径。
+ */
+export const setGameVar = (payload: ISetGameVar, isGlobal = false) => {
+  if (isGlobal) {
+    webgalStore.dispatch(setScriptManagedGlobalVar(payload));
+  } else {
+    stageStateManager.setStageVar(payload);
+  }
+};
 
 /**
  * 设置变量表达式。
@@ -28,19 +40,11 @@ export const setGameVarFromExpression = ({
   isGlobal = false,
   persistGlobal = true,
 }: ISetGameVarFromExpressionPayload) => {
-  const setGameVar = (payload: ISetGameVar) => {
-    if (isGlobal) {
-      webgalStore.dispatch(setScriptManagedGlobalVar(payload));
-    } else {
-      stageStateManager.setStageVar(payload);
-    }
-  };
-
   const normalizedKey = key.trim();
   if (!normalizedKey) {
     return;
   }
-  setGameVar({ key: normalizedKey, value: resolveSetVarValue(value) });
+  setGameVar({ key: normalizedKey, value: resolveSetVarValue(value) }, isGlobal);
   if (isGlobal) {
     logger.debug('设置全局变量：', {
       key: normalizedKey,
@@ -131,10 +135,14 @@ function EvaluateExpression(val: string) {
  */
 export function getValueFromState(key: string) {
   let ret: any;
+  const locals = WebGAL.sceneManager.sceneData.currentLocals;
   const stage = stageStateManager.getCalculationStageState();
   const userData = webgalStore.getState().userData;
   const _Merge = { stage, userData }; // 不要直接合并到一起，防止可能的键冲突
-  if (stage.GameVar.hasOwnProperty(key)) {
+  // 查找链：当前帧局部变量 -> 舞台变量 -> 全局变量
+  if (locals.hasOwnProperty(key)) {
+    ret = locals[key];
+  } else if (stage.GameVar.hasOwnProperty(key)) {
     ret = stage.GameVar[key];
   } else if (userData.globalGameVar.hasOwnProperty(key)) {
     ret = userData.globalGameVar[key];

--- a/packages/webgal/src/Core/gameScripts/setVar.ts
+++ b/packages/webgal/src/Core/gameScripts/setVar.ts
@@ -77,6 +77,8 @@ export const setVar = (sentence: ISentence): IPerform => {
 
 type BaseVal = string | number | boolean | undefined;
 
+const hasOwn = (obj: object, key: string) => Object.prototype.hasOwnProperty.call(obj, key);
+
 export function resolveSetVarValue(valExp: string): string | boolean | number {
   if (/^\s*[a-zA-Z_$][\w$]*\s*\(.*\)\s*$/.test(valExp)) {
     return EvaluateExpression(valExp);
@@ -140,11 +142,12 @@ export function getValueFromState(key: string) {
   const userData = webgalStore.getState().userData;
   const _Merge = { stage, userData }; // 不要直接合并到一起，防止可能的键冲突
   // 查找链：当前帧局部变量 -> 舞台变量 -> 全局变量
-  if (locals.hasOwnProperty(key)) {
+  // 变量名由脚本作者决定，不能用实例上的 hasOwnProperty，否则 hasOwnProperty 这种名字会把方法本身覆盖掉
+  if (hasOwn(locals, key)) {
     ret = locals[key];
-  } else if (stage.GameVar.hasOwnProperty(key)) {
+  } else if (hasOwn(stage.GameVar, key)) {
     ret = stage.GameVar[key];
-  } else if (userData.globalGameVar.hasOwnProperty(key)) {
+  } else if (hasOwn(userData.globalGameVar, key)) {
     ret = userData.globalGameVar[key];
   } else if (key.startsWith('$')) {
     const propertyKey = key.replace('$', '');

--- a/packages/webgal/src/Core/parser/sceneParser.ts
+++ b/packages/webgal/src/Core/parser/sceneParser.ts
@@ -28,6 +28,7 @@ import { setTransition } from '@/Core/gameScripts/setTransition';
 import { unlockBgm } from '@/Core/gameScripts/unlockBgm';
 import { unlockCg } from '@/Core/gameScripts/unlockCg';
 import { callSteam } from '@/Core/gameScripts/callSteam';
+import { returnScript } from '@/Core/gameScripts/returnScript';
 import { end } from '../gameScripts/end';
 import { jumpLabel } from '../gameScripts/jumpLabel';
 import { pixiInit } from '../gameScripts/pixi/pixiInit';
@@ -74,6 +75,7 @@ export const SCRIPT_TAG_MAP = defineScripts({
   applyStyle: ScriptConfig(commandType.applyStyle, applyStyle, { next: true }),
   wait: ScriptConfig(commandType.wait, wait),
   callSteam: ScriptConfig(commandType.callSteam, callSteam, { next: true }),
+  return: ScriptConfig(commandType.return, returnScript),
 });
 
 export const SCRIPT_CONFIG: IConfigInterface[] = Object.values(SCRIPT_TAG_MAP);

--- a/packages/webgal/src/store/userDataInterface.ts
+++ b/packages/webgal/src/store/userDataInterface.ts
@@ -58,6 +58,7 @@ export interface ISaveScene {
   sceneStack: Array<ISceneEntry>; // 场景栈
   sceneName: string; // 场景名称
   sceneUrl: string; // 场景url
+  currentLocals?: IGameVar; // 当前帧的局部变量，旧存档没有此字段
 }
 
 /**


### PR DESCRIPTION
## 背景

为 `callScene` 增加参数传递与返回值，使被调用的场景成为真正的子过程。相关 issue: #421

## 用法

```webgal
; start.txt
callScene:battle.txt -enemy=史莱姆 -hp=100 -writeReturnTo=result;
webgal:战斗结果是 {result};

; battle.txt
webgal:遭遇了{enemy}，血量{hp};
return:1;
```

- `-xxx=yyy` 原样成为被调用场景的局部变量，没有前缀、没有保留字
- `-writeReturnTo=b` 指定返回值写回调用方的哪个变量，`b` 是普通游戏变量，用法同 `setVar`
- `return:expr;` 立即返回并携带返回值；没有 `return` 而自然结束时返回空值
- 变量查找链：当前帧局部变量 → 舞台变量 → 全局变量

## 设计

引入**调用帧**的概念：一帧 = 一次 `callScene`，持有局部变量、返回地址、返回值去向。

关键在于帧的归属：`changeScene` / `choose` **不是**帧操作，它们只是把当前帧正在读的文本换掉，栈和局部变量都不动。所以在被调用的场景里 `changeScene` 之后，参数仍然有效，结束时也仍然返回原调用方。这两个命令不支持参数。

## 实现

**帧结构**：`ISceneEntry` 增加 `locals` / `writeReturnTo`，`ISceneData` 增加 `currentLocals`（栈顶之上的当前帧，因为 `sceneName`/`sceneUrl`/`currentSentenceId` 本来就是摊平存放的当前帧）。

场景栈和 `currentLocals` 是同一个栈的两截，全部经由 `SceneManager.pushFrame()` / `popFrame()` 变更，避免两者脱节。场景末尾原本手写的 pop + restore 也收敛到 `returnFromScene()`，与 `return` 语句共用一条路径。

**参数求值**：不引入任何表达式引擎。`argsParser` 本来就会把 `-a=1` 解析成数字、`-a=true` 解析成布尔；只有经过 `{}` 插值的参数会退化成字符串，在提取参数时按同一套规则还原类型即可。引用变量写 `{b}`，与其他所有参数一致。

**存档**：场景栈本来就整体 `cloneDeep` 进存档，多层嵌套的局部变量随帧免费持久化；只有当前帧的 `currentLocals` 需要单独搬运（saveGame / backlog / loadGame / jumpFromBacklog 各一行）。新字段全部可选，旧存档三处 `?? {}` 兜底，可直接读取。

**其他**：

- `commandType.return` 追加在枚举末尾——旧存档里 `PerformList[].script.command` 是持久化的数值，插在中间会错位
- 场景栈深度上限 64，防止 `callScene` 无限递归
- 修掉一个既有隐患：`saveGame` / `fastSaveGame` 此前没有 `lockSceneWrite` 判定，场景写入期间存档会拿到撕裂状态（栈已变更但场景尚未切换）。加了 `return` 之后这会导致读档重复返回，本 PR 一并加上判定

## 注意

`commandType` 有改动，webgal 包的类型检查依赖 parser 的构建产物，需要先构建 parser 再检查 webgal。

## 验证

两个包 `tsc --noEmit`、eslint、parser 既有测试全部通过。`callScene` 参数解析与 `return` 的四种写法（`return;` / `return:5;` / `return:;` / `return:{x}+1;`）已实测。
